### PR TITLE
[Feat/#30] 현재위치로 동네 검색

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.anbd">
+    <!-- 위치 권한 선언 -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
     <application
         android:label="anbd"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+<key>NSLocationWhenInUseUsageDescription</key>
+		<string>근처 동네를 검색하기 위해 사용자의 현재 위치가 필요합니다</string>
+		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+		<string>근처 동네를 검색하기 위해 사용자의 현재 위치가 필요합니다</string>
+		<key>NSLocationAlwaysUsageDescription</key>
+		<string>근처 동네를 검색하기 위해 사용자의 현재 위치가 필요합니다</string>
+
+</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/common/utils/address_utils.dart
+++ b/lib/common/utils/address_utils.dart
@@ -1,0 +1,23 @@
+String extractDistrictFromAddress(String address) {
+  final parts = address.trim().split(" ");
+  final buffer = <String>[];
+
+  for (final part in parts) {
+    buffer.add(part);
+    if (part.endsWith("동") || part.endsWith("읍") || part.endsWith("면")) {
+      break;
+    }
+  }
+
+  if (buffer.isNotEmpty &&
+      (buffer.last.endsWith("동") ||
+          buffer.last.endsWith("읍") ||
+          buffer.last.endsWith("면"))) {
+    return buffer.join(" ");
+  } else if (parts.length >= 2 &&
+      (parts[0].endsWith("시") || parts[0].endsWith("도"))) {
+    return "${parts[0]} ${parts[1]}";
+  }
+
+  return "";
+}

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -16,7 +16,7 @@ class AppRouter {
 
   static Future<void> setupRouter() async {
     final prefs = await SharedPreferences.getInstance();
-    const String initialLocation = Paths.login;
+    const String initialLocation = Paths.location;
 
     router = GoRouter(
       initialLocation: initialLocation,

--- a/lib/screens/auth/signup/location/location_screen.dart
+++ b/lib/screens/auth/signup/location/location_screen.dart
@@ -5,6 +5,10 @@ import 'package:provider/provider.dart';
 import 'package:anbd/screens/auth/signup/location/location_view_model.dart';
 
 class LocationScreen extends StatelessWidget {
+  const LocationScreen({Key? key}) : super(key: key);
+
+  // initState()는 StatelessWidget에서 사용할 수 없습니다. 제거하거나 StatefulWidget으로 전환해야 합니다.
+
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
@@ -14,12 +18,12 @@ class LocationScreen extends StatelessWidget {
           leadingWidth: 500,
           leading: Builder(
             builder: (context) {
+              // 상단 동네 검색 text field
               return SearchTextField(
                 hintText: '동명(읍, 면) 검색',
                 onBackPressed: () {
                   Navigator.pop(context);
                 },
-                // onSearchChanged는 추가 처리가 필요하면 사용 (여기서는 생략)
                 onSearchChanged: (String value) {},
                 // 엔터 제출 시, Provider의 searchLocation 호출
                 onSubmitted: (String value) {
@@ -33,36 +37,46 @@ class LocationScreen extends StatelessWidget {
         body: SafeArea(
           child: Padding(
             padding: const EdgeInsets.only(left: 15, right: 15, top: 10),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                BasicButton(
-                  text: '현재위치로 찾기',
-                  isClickable: true,
-                  onPressed: () {
-                    showTermsBottomSheet(context);
-                  },
-                  size: BasicButtonSize.SMALL,
-                ),
-                const SizedBox(height: 20),
-                // 상단 텍스트: 검색어가 있을 경우 "검색 단어 검색 결과", 없으면 "근처 동네"
-                Consumer<LocationViewModel>(
-                  builder: (context, viewModel, child) {
-                    final displayText = viewModel.currentSearchTerm.isEmpty
-                        ? "근처 동네"
-                        : "'${viewModel.currentSearchTerm}' 검색 결과";
-                    return Text(
+            child: Consumer<LocationViewModel>(
+              builder: (context, viewModel, child) {
+                final displayText = viewModel.currentSearchTerm.isEmpty
+                    ? "근처 동네"
+                    : "'${viewModel.currentSearchTerm}' 검색 결과";
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    BasicButton(
+                      text: '현재위치로 찾기',
+                      isClickable: true,
+                      onPressed: () {
+                        // 권한 요청 후 위치 가져오기
+                        viewModel.getGeoData();
+                      },
+                      size: BasicButtonSize.SMALL,
+                    ),
+                    const SizedBox(height: 20),
+
+                    // 검색어 표시
+                    Text(
                       displayText,
                       style: AnbdTextStyle.BodySB15,
-                    );
-                  },
-                ),
-                const SizedBox(height: 20),
-                // 예측 결과 리스트 출력
-                Expanded(
-                  child: Consumer<LocationViewModel>(
-                    builder: (context, viewModel, child) {
-                      return ListView.separated(
+                    ),
+                    const SizedBox(height: 20),
+
+                    // 위도/경도 표시 (디버깅용)
+                    if (viewModel.latitude != null &&
+                        viewModel.longitude != null)
+                      Text(
+                        "현재 위치: 위도 ${viewModel.latitude}, 경도 ${viewModel.longitude}",
+                        style: AnbdTextStyle.Body14,
+                      ),
+
+                    const SizedBox(height: 20),
+
+                    // 예측 결과 리스트
+                    Expanded(
+                      child: ListView.separated(
                         itemCount: viewModel.predictions.length,
                         separatorBuilder: (context, index) => const Divider(
                           height: 1,
@@ -84,11 +98,11 @@ class LocationScreen extends StatelessWidget {
                             },
                           );
                         },
-                      );
-                    },
-                  ),
-                ),
-              ],
+                      ),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
         ),

--- a/lib/screens/auth/signup/location/location_screen.dart
+++ b/lib/screens/auth/signup/location/location_screen.dart
@@ -7,8 +7,6 @@ import 'package:anbd/screens/auth/signup/location/location_view_model.dart';
 class LocationScreen extends StatelessWidget {
   const LocationScreen({Key? key}) : super(key: key);
 
-  // initState()는 StatelessWidget에서 사용할 수 없습니다. 제거하거나 StatefulWidget으로 전환해야 합니다.
-
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
@@ -18,15 +16,14 @@ class LocationScreen extends StatelessWidget {
           leadingWidth: 500,
           leading: Builder(
             builder: (context) {
-              // 상단 동네 검색 text field
+              /// 상단 동네 검색 text field
               return SearchTextField(
-                hintText: '동명(읍, 면) 검색',
+                hintText: '동명(읍, 면)으로 검색',
                 onBackPressed: () {
                   Navigator.pop(context);
                 },
-                onSearchChanged: (String value) {},
-                // 엔터 제출 시, Provider의 searchLocation 호출
-                onSubmitted: (String value) {
+                onSearchChanged: (_) {},
+                onSubmitted: (value) {
                   Provider.of<LocationViewModel>(context, listen: false)
                       .searchLocation(value);
                 },
@@ -36,12 +33,14 @@ class LocationScreen extends StatelessWidget {
         ),
         body: SafeArea(
           child: Padding(
-            padding: const EdgeInsets.only(left: 15, right: 15, top: 10),
+            padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
             child: Consumer<LocationViewModel>(
-              builder: (context, viewModel, child) {
-                final displayText = viewModel.currentSearchTerm.isEmpty
+              builder: (context, viewModel, _) {
+                final displayText = viewModel.isFromLocation
                     ? "근처 동네"
                     : "'${viewModel.currentSearchTerm}' 검색 결과";
+
+                final items = viewModel.nearbyDistricts;
 
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -50,52 +49,32 @@ class LocationScreen extends StatelessWidget {
                       text: '현재위치로 찾기',
                       isClickable: true,
                       onPressed: () {
-                        // 권한 요청 후 위치 가져오기
                         viewModel.getGeoData();
                       },
                       size: BasicButtonSize.SMALL,
                     ),
                     const SizedBox(height: 20),
-
-                    // 검색어 표시
-                    Text(
-                      displayText,
-                      style: AnbdTextStyle.BodySB15,
-                    ),
+                    Text(displayText, style: AnbdTextStyle.BodySB15),
                     const SizedBox(height: 20),
 
-                    // 위도/경도 표시 (디버깅용)
-                    if (viewModel.latitude != null &&
-                        viewModel.longitude != null)
-                      Text(
-                        "현재 위치: 위도 ${viewModel.latitude}, 경도 ${viewModel.longitude}",
-                        style: AnbdTextStyle.Body14,
-                      ),
-
-                    const SizedBox(height: 20),
-
-                    // 예측 결과 리스트
+                    /// 근처 동네 검색 결과
                     Expanded(
                       child: ListView.separated(
-                        itemCount: viewModel.predictions.length,
-                        separatorBuilder: (context, index) => const Divider(
+                        itemCount: items.length,
+                        separatorBuilder: (_, __) => const Divider(
                           height: 1,
                           color: AnbdColor.systemGray02,
                         ),
                         itemBuilder: (context, index) {
-                          final prediction = viewModel.predictions[index];
                           return ListTile(
                             dense: true,
                             contentPadding:
-                                const EdgeInsets.symmetric(horizontal: 0.0),
+                                const EdgeInsets.symmetric(horizontal: 0),
                             title: Text(
-                              prediction.description ??
-                                  "검색 결과가 없어요.\n동네 이름을 다시 확인해주세요!",
+                              items[index],
                               style: AnbdTextStyle.Body15,
                             ),
-                            onTap: () {
-                              viewModel.onItemClicked(prediction);
-                            },
+                            onTap: () {},
                           );
                         },
                       ),
@@ -107,21 +86,6 @@ class LocationScreen extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-
-  void showTermsBottomSheet(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true, // 화면 대부분을 차지하도록
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-          top: Radius.circular(16),
-        ),
-      ),
-      builder: (context) {
-        return const TermsBottomSheet();
-      },
     );
   }
 }

--- a/lib/screens/auth/signup/location/location_view_model.dart
+++ b/lib/screens/auth/signup/location/location_view_model.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'package:anbd/common/utils/address_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_google_maps_webservices/places.dart';
@@ -25,6 +26,7 @@ class LocationViewModel extends ChangeNotifier {
     _places = GoogleMapsPlaces(apiKey: googleApiKey);
   }
 
+  /// 검색어로 근처 동네 리스트 검색
   Future<void> searchLocation(String query) async {
     isFromLocation = false;
     currentSearchTerm = query;
@@ -44,7 +46,6 @@ class LocationViewModel extends ChangeNotifier {
 
     if (autocompleteResponse.isOkay) {
       final Set<String> districtSet = {};
-      log("🧾 Autocomplete Raw Response: ${autocompleteResponse.toJson()}");
 
       for (final prediction in autocompleteResponse.predictions) {
         final placeId = prediction.placeId;
@@ -56,7 +57,6 @@ class LocationViewModel extends ChangeNotifier {
           );
 
           if (details == null || details.result == null) {
-            log("Details not found for placeId: $placeId");
             continue;
           }
 
@@ -70,7 +70,6 @@ class LocationViewModel extends ChangeNotifier {
             districtSet.add(parsed);
           }
         } catch (e) {
-          log("Error fetching details for placeId: $placeId - $e");
           continue;
         }
       }
@@ -113,8 +112,6 @@ class LocationViewModel extends ChangeNotifier {
     isFromLocation = true;
     notifyListeners();
     await searchNearbyPlaces();
-
-    log("위도: \$latitude, 경도: \$longitude");
   }
 
   /// 위치 정보로 근처 동네 리스트 검색
@@ -123,7 +120,7 @@ class LocationViewModel extends ChangeNotifier {
 
     final response = await _places.searchNearbyWithRadius(
       Location(lat: double.parse(latitude!), lng: double.parse(longitude!)),
-      1000,
+      2000,
       language: 'ko',
     );
 
@@ -137,8 +134,6 @@ class LocationViewModel extends ChangeNotifier {
         );
         final fullAddress = detail.result.formattedAddress;
 
-        log("📍 Raw address: $fullAddress");
-
         if (fullAddress == null) continue;
 
         final parsed = extractDistrictFromAddress(fullAddress);
@@ -150,34 +145,9 @@ class LocationViewModel extends ChangeNotifier {
       nearbyDistricts = districtSet.toList();
       notifyListeners();
     } else {
-      log("주소 검색 실패: ${response.errorMessage}");
       nearbyDistricts = [];
       notifyListeners();
     }
-  }
-
-  String extractDistrictFromAddress(String address) {
-    final parts = address.trim().split(" ");
-    final buffer = <String>[];
-
-    for (final part in parts) {
-      buffer.add(part);
-      if (part.endsWith("동") || part.endsWith("읍") || part.endsWith("면")) {
-        break;
-      }
-    }
-
-    if (buffer.isNotEmpty &&
-        (buffer.last.endsWith("동") ||
-            buffer.last.endsWith("읍") ||
-            buffer.last.endsWith("면"))) {
-      return buffer.join(" ");
-    } else if (parts.length >= 2 &&
-        (parts[0].endsWith("시") || parts[0].endsWith("도"))) {
-      return "${parts[0]} ${parts[1]}";
-    }
-
-    return "";
   }
 
   @override

--- a/lib/widgets/search_text_field.dart
+++ b/lib/widgets/search_text_field.dart
@@ -43,6 +43,7 @@ class _SearchTextFieldState extends State<SearchTextField> {
   @override
   Widget build(BuildContext context) {
     return Material(
+      color: Colors.white,
       child: Row(
         children: [
           IconButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -757,6 +757,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.3.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.13"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f84a188e79a35c687c132a0a0556c254747a08561e99ab933f12f6ca71ef3c98
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.6"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.3"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
 
   #날 형식 변환
   intl: ^0.19.0
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   geolocator_windows
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
- #30 

## 🚀 Description
### 사용자의 현재 위치(좌표)로 근처 동네를 검색하는 기능을 구현하였습니다.

### geolocator
- 사용자의 위치정보는 geolocator 패키지를 이용하였습니다.
- 현재 위치로 검색 버튼을 처음 클릭하였을때 위치 권한 부여 여부를 받고 동의 받을때 사용자의 현재 좌표를 받아옵니다.
```dart
Future<void> getGeoData() async {
    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
    if (!serviceEnabled) {
      log('위치 서비스가 꺼져 있습니다.');
      return;
    }

    LocationPermission permission = await Geolocator.checkPermission();
    if (permission == LocationPermission.denied ||
        permission == LocationPermission.deniedForever) {
      permission = await Geolocator.requestPermission();
      if (permission != LocationPermission.always &&
          permission != LocationPermission.whileInUse) {
        log('위치 권한이 거부되었습니다.');
        return;
      }
    }

    Position position = await Geolocator.getCurrentPosition(
      desiredAccuracy: LocationAccuracy.high,
    );

    latitude = position.latitude.toString();
    longitude = position.longitude.toString();

    isFromLocation = true;
    notifyListeners();
    await searchNearbyPlaces();
  }
```

### flutter_google_maps_webservices
- 좌표를 가지고 근처 동네를 검색하기 위해 flutter_google_maps_webservices 패키지를 사용하였습니다.
- searchNearbyWithRadius()함수를 사용하여 설정한 범위내의 지역을 불러옵니다.
```dart
Future<void> searchNearbyPlaces() async {
    if (latitude == null || longitude == null) return;

    final response = await _places.searchNearbyWithRadius(
      Location(lat: double.parse(latitude!), lng: double.parse(longitude!)),
      2000,
      language: 'ko',
    );

    if (response.isOkay && response.results.isNotEmpty) {
      final Set<String> districtSet = {};

      for (final place in response.results) {
        final detail = await _places.getDetailsByPlaceId(
          place.placeId,
          language: 'ko',
        );
        final fullAddress = detail.result.formattedAddress;

        if (fullAddress == null) continue;

        final parsed = extractDistrictFromAddress(fullAddress);
        if (parsed.isNotEmpty) {
          districtSet.add(parsed);
        }
      }

      nearbyDistricts = districtSet.toList();
      notifyListeners();
    } else {
      nearbyDistricts = [];
      notifyListeners();
    }
  }
```

### extractDistrictFromAddress
- searchNearbyWithRadius()함수 내에서는 동네로(ex. 서초동)으로 불러오는게 불가능해서 따로 필터링 작업을 진행하였습니다.
- 범위내의 모든 지역(주소)를 받은 다음 ~동으로 끝나는 응답값만 추출하고 이들 중 ~동 이후 단어는 삭제하였습니다. (ex. fullAdress: 서울특별시 서초구 서초동 134, extractDistrictFromAddress: 서울특별시 서초구 서초동)
- extractDistrictFromAddress함수는 코드 재사용성과 분리를 위해 `address_utils.dart`파일에 작성하였습니다.


## 📸 Screenshot

https://github.com/user-attachments/assets/59da5345-fa68-43de-9ffe-f30a4379f510



## 📢 Notes
사용자 위치 허용 퍼미션을 안드로이드, ios 둘 다 진행하긴 하였는데 ios 애뮬로는 테스트해보지 못했습니다.
google map api도 아직 안드로이드밖에 동작하지 않기 때문에 일단 안드로이드 기준으로 진행하였습니다.