### PR TITLE
[Feat/#33] 회원가입 api 연동

### DIFF
--- a/lib/constants/apis.dart
+++ b/lib/constants/apis.dart
@@ -11,4 +11,5 @@ abstract class Apis {
   static const String getSharePostList = "share-posts";
 
   /// user 관련 api
-  static const String putUsersProfiles = "users/profiles";}
+  static const String putUsersProfiles = "users/profiles";
+}

--- a/lib/constants/apis.dart
+++ b/lib/constants/apis.dart
@@ -9,4 +9,6 @@ abstract class Apis {
   /// 토큰 관련 api
   static const String getAccessToken = "auth/mobile/google";
   static const String getSharePostList = "share-posts";
-}
+
+  /// user 관련 api
+  static const String putUsersProfiles = "users/profiles";}

--- a/lib/data/repository/local/secure_storage_repository.dart
+++ b/lib/data/repository/local/secure_storage_repository.dart
@@ -33,7 +33,7 @@ class SecureStorageRepository {
     await _storage.write(key: "user_email", value: email);
   }
 
-  Future<void> readUserEmail() async {
+  Future<String?> readUserEmail() async {
     await _storage.read(key: "user_email");
   }
 
@@ -41,7 +41,7 @@ class SecureStorageRepository {
     await _storage.write(key: "user_gender", value: gender);
   }
 
-  Future<void> readUserGender() async {
+  Future<String?> readUserGender() async {
     await _storage.read(key: "user_gender");
   }
 
@@ -49,7 +49,7 @@ class SecureStorageRepository {
     await _storage.write(key: "user_birth_date", value: birthDate);
   }
 
-  Future<void> readUserBirthDate() async {
+  Future<String?> readUserBirthDate() async {
     await _storage.read(key: "user_birth_date");
   }
 
@@ -57,7 +57,7 @@ class SecureStorageRepository {
     await _storage.write(key: "nearby_districts", value: nearbyDistricts);
   }
 
-  Future<void> readUserNearbyDistricts() async {
+  Future<String?> readUserNearbyDistricts() async {
     await _storage.read(key: "nearby_districts");
   }
 }

--- a/lib/data/repository/local/secure_storage_repository.dart
+++ b/lib/data/repository/local/secure_storage_repository.dart
@@ -34,7 +34,7 @@ class SecureStorageRepository {
   }
 
   Future<String?> readUserEmail() async {
-    await _storage.read(key: "user_email");
+    return await _storage.read(key: "user_email");
   }
 
   Future<void> saveUserGender(String gender) async {
@@ -42,7 +42,7 @@ class SecureStorageRepository {
   }
 
   Future<String?> readUserGender() async {
-    await _storage.read(key: "user_gender");
+    return await _storage.read(key: "user_gender");
   }
 
   Future<void> saveUserBirthDate(String birthDate) async {
@@ -50,7 +50,7 @@ class SecureStorageRepository {
   }
 
   Future<String?> readUserBirthDate() async {
-    await _storage.read(key: "user_birth_date");
+    return await _storage.read(key: "user_birth_date");
   }
 
   Future<void> saveUserNearbyDistricts(String nearbyDistricts) async {
@@ -58,6 +58,6 @@ class SecureStorageRepository {
   }
 
   Future<String?> readUserNearbyDistricts() async {
-    await _storage.read(key: "nearby_districts");
+    return await _storage.read(key: "nearby_districts");
   }
 }

--- a/lib/data/repository/local/secure_storage_repository.dart
+++ b/lib/data/repository/local/secure_storage_repository.dart
@@ -52,4 +52,12 @@ class SecureStorageRepository {
   Future<void> readUserBirthDate() async {
     await _storage.read(key: "user_birth_date");
   }
+
+  Future<void> saveUserNearbyDistricts(String nearbyDistricts) async {
+    await _storage.write(key: "nearby_districts", value: nearbyDistricts);
+  }
+
+  Future<void> readUserNearbyDistricts() async {
+    await _storage.read(key: "nearby_districts");
+  }
 }

--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -12,9 +12,9 @@ class UserService {
 
   /// 최초 회원가입시 사용자 프로필 업데이트
   Future<TokenResponse> putUsersProfiles(String? gender, String? birthDate,
-      String? neighborhood, Set<String> shareCategories) async {
+      String? neighborhood, List<String> shareCategories) async {
     try {
-      final response = await _apiClient.dio.post(
+      final response = await _apiClient.dio.put(
         options: Options(
           extra: {'skipAuthToken': false},
         ),

--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -1,6 +1,63 @@
+import 'dart:developer';
+
+import 'package:anbd/constants/constants.dart';
 import 'package:anbd/data/di/api_client.dart';
+import 'package:anbd/data/dto/response/base_response.dart';
+import 'package:anbd/data/dto/response/token_response.dart';
+import 'package:dio/dio.dart';
 
 class UserService {
   final ApiClient _apiClient = ApiClient();
   static const apiVersion = "v1/";
+
+  /// 최초 회원가입시 사용자 프로필 업데이트
+  Future<TokenResponse> putUsersProfiles() async {
+    try {
+      final response = await _apiClient.dio.post(
+        options: Options(
+          extra: {'skipAuthToken': false},
+        ),
+        apiVersion + Apis.putUsersProfiles,
+        data: {
+          'gender': authCode,
+          'birthDate': authCode,
+          'neighborhood': authCode,
+          'shareCategories': authCode,
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final baseResponse = BaseResponse<TokenResponse>.fromJson(
+          response.data,
+          (contentJson) => TokenResponse.fromJson(contentJson),
+        );
+
+        log("응답 메세지 : ${baseResponse.body}");
+
+        return baseResponse.body;
+      } else if (response.statusCode == 400) {
+        /// Bad Request
+        throw Exception('Bad Request (400). Please check the request.');
+      } else if (response.statusCode == 401) {
+        /// 인증 실패
+        throw Exception('Authentication failed (401).');
+      } else if (response.statusCode == 404) {
+        /// Not Found
+        throw Exception('Not Found (404).');
+      } else if (response.statusCode == 406) {
+        /// Not Acceptable
+        throw Exception('Not Acceptable (406).');
+      } else if (response.statusCode == 500) {
+        /// Internal Server Error
+        throw Exception('Internal Server Error (500).');
+      } else {
+        throw Exception(
+            'Failed to post GoogleAuth: ${response.statusCode} ${response.statusMessage}');
+      }
+    } on DioException catch (e) {
+      throw Exception('Error: ${e.response?.data ?? e.message}');
+    } catch (e) {
+      throw Exception('An unexpected error occurred: $e');
+    }
+  }
 }

--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -11,7 +11,8 @@ class UserService {
   static const apiVersion = "v1/";
 
   /// 최초 회원가입시 사용자 프로필 업데이트
-  Future<TokenResponse> putUsersProfiles() async {
+  Future<TokenResponse> putUsersProfiles(String? gender, String? birthDate,
+      String? neighborhood, Set<String> shareCategories) async {
     try {
       final response = await _apiClient.dio.post(
         options: Options(
@@ -19,10 +20,10 @@ class UserService {
         ),
         apiVersion + Apis.putUsersProfiles,
         data: {
-          'gender': authCode,
-          'birthDate': authCode,
-          'neighborhood': authCode,
-          'shareCategories': authCode,
+          'gender': gender,
+          'birthDate': birthDate,
+          'neighborhood': neighborhood,
+          'shareCategories': shareCategories,
         },
       );
 

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -16,8 +16,7 @@ class AppRouter {
 
   static Future<void> setupRouter() async {
     final prefs = await SharedPreferences.getInstance();
-    
-    const String initialLocation = Paths.onboarding;
+    const String initialLocation = Paths.login;
 
     router = GoRouter(
       initialLocation: initialLocation,

--- a/lib/screens/auth/login/login_view_model.dart
+++ b/lib/screens/auth/login/login_view_model.dart
@@ -5,7 +5,6 @@ import 'package:anbd/data/repository/local/secure_storage_repository.dart';
 import 'package:anbd/data/service/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 class LoginViewModel extends ChangeNotifier {

--- a/lib/screens/auth/signup/category/category_screen.dart
+++ b/lib/screens/auth/signup/category/category_screen.dart
@@ -2,6 +2,7 @@ import 'package:anbd/constants/constants.dart';
 import 'package:anbd/screens/auth/signup/category/category_view_model.dart';
 import 'package:anbd/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 class CategoryScreen extends StatelessWidget {
@@ -33,7 +34,7 @@ class CategoryScreen extends StatelessWidget {
                         itemCount: viewModel.categories.length,
                         gridDelegate:
                             const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 3, // 한 행에 3개
+                          crossAxisCount: 3,
                           childAspectRatio: 1,
                         ),
                         itemBuilder: (context, index) {
@@ -72,6 +73,7 @@ class CategoryScreen extends StatelessWidget {
                           isClickable: true,
                           onPressed: () {
                             viewModel.selectCategoryComplete(context);
+                            context.push(Paths.home);
                           },
                         ),
                       ),

--- a/lib/screens/auth/signup/category/category_screen.dart
+++ b/lib/screens/auth/signup/category/category_screen.dart
@@ -1,5 +1,6 @@
 import 'package:anbd/constants/constants.dart';
 import 'package:anbd/screens/auth/signup/category/category_view_model.dart';
+import 'package:anbd/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -20,8 +21,8 @@ class CategoryScreen extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     const SizedBox(height: 30),
-                    const Text(
-                      "마지막 단계에요!\nAI 추천을 위해 {name}님의 \n관심사를 선택해주세요",
+                    Text(
+                      "마지막 단계에요!\nAI 추천을 위해 ${viewModel.name ?? '사용자'}님의 \n관심사를 선택해주세요",
                       style: AnbdTextStyle.TitleSB18,
                     ),
                     const SizedBox(height: 20),
@@ -37,10 +38,12 @@ class CategoryScreen extends StatelessWidget {
                         ),
                         itemBuilder: (context, index) {
                           final category = viewModel.categories[index];
+                          final isSelected = viewModel.selectedCategoryKeys
+                              .contains(category.categoryKey);
+
                           return InkWell(
                             onTap: () {
-                              viewModel.selectCategory(
-                                  category.categoryKey, context);
+                              viewModel.toggleCategory(category.categoryKey);
                             },
                             child: Column(
                               mainAxisAlignment: MainAxisAlignment.center,
@@ -49,7 +52,11 @@ class CategoryScreen extends StatelessWidget {
                                 const SizedBox(height: 8),
                                 Text(
                                   category.label,
-                                  style: AnbdTextStyle.BodySB15,
+                                  style: AnbdTextStyle.BodySB15.copyWith(
+                                    color: isSelected
+                                        ? AnbdColor.blue
+                                        : Colors.black,
+                                  ),
                                 ),
                               ],
                             ),
@@ -57,6 +64,17 @@ class CategoryScreen extends StatelessWidget {
                         },
                       ),
                     ),
+                    if (viewModel.selectedCategoryKeys.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16.0),
+                        child: BasicButton(
+                          text: "선택 완료",
+                          isClickable: true,
+                          onPressed: () {
+                            viewModel.selectCategoryComplete(context);
+                          },
+                        ),
+                      ),
                   ],
                 ),
               );

--- a/lib/screens/auth/signup/category/category_view_model.dart
+++ b/lib/screens/auth/signup/category/category_view_model.dart
@@ -28,20 +28,25 @@ class CategoryViewModel extends ChangeNotifier {
   final UserService userService = GetIt.instance<UserService>();
 
   String? _name;
+
   String? get name => _name;
 
   String? _gender;
+
   String? get gender => _gender;
 
   String? _birthDate;
+
   String? get birthDate => _birthDate;
 
   String? _neighborhood;
+
   String? get neighborhood => _neighborhood;
 
   /// 선택한 카테고리 저장 리스트
-  final Set<String> _selectedCategoryKeys = {};
-  Set<String> get selectedCategoryKeys => _selectedCategoryKeys;
+  final List<String> _selectedCategoryKeys = [];
+
+  List<String> get selectedCategoryKeys => _selectedCategoryKeys;
 
   Future<void> _loadStoreRepository() async {
     _name = await _secureStorage.readUserName();
@@ -65,64 +70,73 @@ class CategoryViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// 선택 완료 시 다음 화면으로 이동
+  /// 선택 완료 시 회원가입 api 호출
   void selectCategoryComplete(BuildContext context) async {
     await userService.putUsersProfiles(
         gender, birthDate, neighborhood, selectedCategoryKeys);
-
-    log("$selectedCategoryKeys");
-    context.push(Paths.home);
   }
 
   /// 카테고리 목록
   final List<CategoryItem> categories = [
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}food.svg'),
-        label: "음식",
-        categoryKey: "food"),
+      icon: SvgPicture.asset('${baseSvgPicture}food.svg'),
+      label: "음식",
+      categoryKey: "FOOD",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}digital.svg'),
-        label: "디지털 기기",
-        categoryKey: "digital"),
+      icon: SvgPicture.asset('${baseSvgPicture}digital.svg'),
+      label: "디지털 기기",
+      categoryKey: "DIGITAL",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}home_appliance.svg'),
-        label: "생활/가전",
-        categoryKey: "home_appliance"),
+      icon: SvgPicture.asset('${baseSvgPicture}home_appliance.svg'),
+      label: "생활/가전",
+      categoryKey: "HOME_APPLIANCE",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}furniture_interior.svg'),
-        label: "가구/인테리어",
-        categoryKey: "furniture_interior"),
+      icon: SvgPicture.asset('${baseSvgPicture}furniture_interior.svg'),
+      label: "가구/인테리어",
+      categoryKey: "FURNITURE_INTERIOR",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}woman_accessory.svg'),
-        label: "여성잡화",
-        categoryKey: "woman_accessory"),
+      icon: SvgPicture.asset('${baseSvgPicture}woman_accessory.svg'),
+      label: "여성잡화",
+      categoryKey: "WOMAN_ACCESSORY",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}man_fashion.svg'),
-        label: "남성패션/잡화",
-        categoryKey: "man_fashion"),
+      icon: SvgPicture.asset('${baseSvgPicture}man_fashion.svg'),
+      label: "남성패션/잡화",
+      categoryKey: "MAN_FASHION",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}living_kitchen.svg'),
-        label: "생활/주방",
-        categoryKey: "living_kitchen"),
+      icon: SvgPicture.asset('${baseSvgPicture}living_kitchen.svg'),
+      label: "생활/주방",
+      categoryKey: "LIVING_KITCHEN",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}sport_leisure.svg'),
-        label: "스포츠/레저",
-        categoryKey: "sport_leisure"),
+      icon: SvgPicture.asset('${baseSvgPicture}sport_leisure.svg'),
+      label: "스포츠/레저",
+      categoryKey: "SPORT_LEISURE",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}hobby_game_music.svg'),
-        label: "취미/게임/음반",
-        categoryKey: "hobby_game_music"),
+      icon: SvgPicture.asset('${baseSvgPicture}hobby_game_music.svg'),
+      label: "취미/게임/음반",
+      categoryKey: "HOBBY_GAME_MUSIC",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}beauty_cosmetic.svg'),
-        label: "뷰티/미용",
-        categoryKey: "beauty_cosmetic"),
+      icon: SvgPicture.asset('${baseSvgPicture}beauty_cosmetic.svg'),
+      label: "뷰티/미용",
+      categoryKey: "BEAUTY_COSMETIC",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}plant.svg'),
-        label: "식물",
-        categoryKey: "plant"),
+      icon: SvgPicture.asset('${baseSvgPicture}plant.svg'),
+      label: "식물",
+      categoryKey: "PLANT",
+    ),
     CategoryItem(
-        icon: SvgPicture.asset('${baseSvgPicture}book.svg'),
-        label: "도서",
-        categoryKey: "book"),
+      icon: SvgPicture.asset('${baseSvgPicture}book.svg'),
+      label: "도서",
+      categoryKey: "BOOK",
+    ),
   ];
 }

--- a/lib/screens/auth/signup/category/category_view_model.dart
+++ b/lib/screens/auth/signup/category/category_view_model.dart
@@ -1,7 +1,11 @@
+import 'dart:developer';
+
 import 'package:anbd/constants/constants.dart';
 import 'package:anbd/data/repository/local/secure_storage_repository.dart';
+import 'package:anbd/data/service/user_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
 String baseSvgPicture = 'assets/svg/category/';
@@ -21,21 +25,34 @@ class CategoryItem {
 
 class CategoryViewModel extends ChangeNotifier {
   final SecureStorageRepository _secureStorage = SecureStorageRepository();
+  final UserService userService = GetIt.instance<UserService>();
 
   String? _name;
   String? get name => _name;
+
+  String? _gender;
+  String? get gender => _gender;
+
+  String? _birthDate;
+  String? get birthDate => _birthDate;
+
+  String? _neighborhood;
+  String? get neighborhood => _neighborhood;
 
   /// 선택한 카테고리 저장 리스트
   final Set<String> _selectedCategoryKeys = {};
   Set<String> get selectedCategoryKeys => _selectedCategoryKeys;
 
-  Future<void> _loadName() async {
+  Future<void> _loadStoreRepository() async {
     _name = await _secureStorage.readUserName();
+    _gender = await _secureStorage.readUserGender();
+    _birthDate = await _secureStorage.readUserBirthDate();
+    _neighborhood = await _secureStorage.readUserNearbyDistricts();
     notifyListeners();
   }
 
   CategoryViewModel() {
-    _loadName();
+    Future.microtask(() => _loadStoreRepository());
   }
 
   /// 카테고리 선택 토글
@@ -50,6 +67,10 @@ class CategoryViewModel extends ChangeNotifier {
 
   /// 선택 완료 시 다음 화면으로 이동
   void selectCategoryComplete(BuildContext context) async {
+    await userService.putUsersProfiles(
+        gender, birthDate, neighborhood, selectedCategoryKeys);
+
+    log("$selectedCategoryKeys");
     context.push(Paths.home);
   }
 

--- a/lib/screens/auth/signup/category/category_view_model.dart
+++ b/lib/screens/auth/signup/category/category_view_model.dart
@@ -1,11 +1,58 @@
 import 'package:anbd/constants/constants.dart';
+import 'package:anbd/data/repository/local/secure_storage_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
 String baseSvgPicture = 'assets/svg/category/';
 
+/// 카테고리 아이템 모델
+class CategoryItem {
+  final SvgPicture icon;
+  final String label;
+  final String categoryKey;
+
+  CategoryItem({
+    required this.label,
+    required this.categoryKey,
+    required this.icon,
+  });
+}
+
 class CategoryViewModel extends ChangeNotifier {
+  final SecureStorageRepository _secureStorage = SecureStorageRepository();
+
+  String? _name;
+  String? get name => _name;
+
+  /// 선택한 카테고리 저장 리스트
+  final Set<String> _selectedCategoryKeys = {};
+  Set<String> get selectedCategoryKeys => _selectedCategoryKeys;
+
+  Future<void> _loadName() async {
+    _name = await _secureStorage.readUserName();
+    notifyListeners();
+  }
+
+  CategoryViewModel() {
+    _loadName();
+  }
+
+  /// 카테고리 선택 토글
+  void toggleCategory(String categoryKey) {
+    if (_selectedCategoryKeys.contains(categoryKey)) {
+      _selectedCategoryKeys.remove(categoryKey);
+    } else {
+      _selectedCategoryKeys.add(categoryKey);
+    }
+    notifyListeners();
+  }
+
+  /// 선택 완료 시 다음 화면으로 이동
+  void selectCategoryComplete(BuildContext context) async {
+    context.push(Paths.home);
+  }
+
   /// 카테고리 목록
   final List<CategoryItem> categories = [
     CategoryItem(
@@ -57,22 +104,4 @@ class CategoryViewModel extends ChangeNotifier {
         label: "도서",
         categoryKey: "book"),
   ];
-
-  /// 카테고리를 선택하면 다음 화면으로 이동
-  void selectCategory(String categoryKey, BuildContext context) {
-    context.push(Paths.home);
-  }
-}
-
-/// 카테고리 아이템 모델
-class CategoryItem {
-  final SvgPicture icon;
-  final String label;
-  final String categoryKey;
-
-  CategoryItem({
-    required this.label,
-    required this.categoryKey,
-    required this.icon,
-  });
 }

--- a/lib/screens/auth/signup/location/location_screen.dart
+++ b/lib/screens/auth/signup/location/location_screen.dart
@@ -74,7 +74,10 @@ class LocationScreen extends StatelessWidget {
                               items[index],
                               style: AnbdTextStyle.Body15,
                             ),
-                            onTap: () {},
+                            onTap: () {
+                              viewModel.selectAndSaveDistrict(items[index]);
+                              showTermsBottomSheet(context);
+                            },
                           );
                         },
                       ),
@@ -86,6 +89,16 @@ class LocationScreen extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  void showTermsBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return const TermsBottomSheet();
+      },
     );
   }
 }

--- a/lib/screens/auth/signup/location/location_view_model.dart
+++ b/lib/screens/auth/signup/location/location_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'package:anbd/common/utils/address_utils.dart';
+import 'package:anbd/data/repository/local/secure_storage_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_google_maps_webservices/places.dart';
@@ -21,6 +22,9 @@ class LocationViewModel extends ChangeNotifier {
   /// 위도/경도
   String? latitude;
   String? longitude;
+
+  String? _selectedDistrict;
+  String? get selectedDistrict => _selectedDistrict;
 
   LocationViewModel() {
     _places = GoogleMapsPlaces(apiKey: googleApiKey);
@@ -148,6 +152,24 @@ class LocationViewModel extends ChangeNotifier {
       nearbyDistricts = [];
       notifyListeners();
     }
+  }
+
+  /// 사용자가 선택한 동네 저장
+  Future<void> selectAndSaveDistrict(String district) async {
+    _selectedDistrict = district;
+    notifyListeners();
+
+    final parts = district.split(' ');
+    String trimmedDistrict = district;
+
+    if (parts.length >= 2) {
+      trimmedDistrict = "${parts[parts.length - 2]} ${parts.last}";
+    }
+
+    // 저장 동네는 자치구/행정구 + 동/읍/면 조합
+    final SecureStorageRepository secureStorage = SecureStorageRepository();
+    await secureStorage.saveUserNearbyDistricts(trimmedDistrict);
+    log("✅ 저장된 동네: $trimmedDistrict");
   }
 
   @override

--- a/lib/screens/auth/signup/question/question_viewmodel.dart
+++ b/lib/screens/auth/signup/question/question_viewmodel.dart
@@ -7,9 +7,6 @@ import 'package:intl/intl.dart';
 class QuestionViewModel extends ChangeNotifier {
   final SecureStorageRepository _secureStorage = SecureStorageRepository();
 
-  String? _selectedGender; // 선택된 성별
-  DateTime? _selectedDate; // 선택된 날짜(출생일 등)
-
   /// 비동기 로드를 통해 받아온 name
   String? _name;
   String? get name => _name;
@@ -30,9 +27,11 @@ class QuestionViewModel extends ChangeNotifier {
   }
 
   /// 성별 Getter
+  String? _selectedGender;
   String? get selectedGender => _selectedGender;
 
   /// 날짜 Getter
+  DateTime? _selectedDate;
   DateTime? get selectedDate => _selectedDate;
 
   /// '다음' 버튼 표시 여부 (성별과 날짜 모두 선택해야 true)
@@ -56,15 +55,15 @@ class QuestionViewModel extends ChangeNotifier {
 
   Future<void> saveUserInfo(
       String? selectedGender, String? selectedDate) async {
-    final SecureStorageRepository secureStorage = SecureStorageRepository();
-
     if (selectedGender == '남성') {
       selectedGender = 'MALE';
     } else {
       selectedGender = 'FEMALE';
     }
-    await secureStorage.saveUserGender(selectedGender);
-    await secureStorage.saveUserBirthDate(selectedDate!);
+
+    log("성별 : $selectedGender, 생일 : $selectedDate");
+    _secureStorage.saveUserGender(selectedGender);
+    _secureStorage.saveUserBirthDate(selectedDate!);
   }
 
   @override

--- a/lib/widgets/terms_bottom_sheet.dart
+++ b/lib/widgets/terms_bottom_sheet.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
-// 🔹 약관 데이터 모델
+/// 약관 데이터 모델
 class _Term {
   final String title;
   final bool isRequired;
@@ -45,48 +45,55 @@ class _TermsBottomSheetState extends State<TermsBottomSheet> {
     bool isAllRequiredAgreed =
         _terms.where((t) => t.isRequired).every((term) => term.agreed);
 
-    return SizedBox(
-      height: sheetHeight,
-      child: Column(
-        children: [
-          /// 상단 드래그 인디케이터
-          Container(
-            width: 40,
-            height: 4,
-            margin: const EdgeInsets.only(top: 12, bottom: 8),
-            decoration: BoxDecoration(
-              color: AnbdColor.systemGray03,
-              borderRadius: BorderRadius.circular(2),
+    return Material(
+      color: AnbdColor.white,
+      borderRadius: const BorderRadius.vertical(
+        top: Radius.circular(16),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        height: sheetHeight,
+        child: Column(
+          children: [
+            /// 상단 드래그 인디케이터
+            Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(top: 12, bottom: 8),
+              decoration: BoxDecoration(
+                color: AnbdColor.systemGray03,
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
-          ),
-          // 모두 동의
-          _buildAllAgreeTile(),
+            // 모두 동의
+            _buildAllAgreeTile(),
 
-          const Divider(color: AnbdColor.systemGray02, thickness: 1),
+            const Divider(color: AnbdColor.systemGray02, thickness: 1),
 
-          /// 약관 목록
-          Expanded(
-            child: ListView.builder(
-              itemCount: _terms.length,
-              itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 10),
-                  child: _buildTermTile(_terms[index]),
-                );
-              },
+            /// 약관 목록
+            Expanded(
+              child: ListView.builder(
+                itemCount: _terms.length,
+                itemBuilder: (context, index) {
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _buildTermTile(_terms[index]),
+                  );
+                },
+              ),
             ),
-          ),
 
-          /// 시작하기 버튼
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-            child: BasicButton(
-              text: '시작하기',
-              isClickable: isAllRequiredAgreed,
-              onPressed: _onStartPressed,
+            /// 시작하기 버튼
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+              child: BasicButton(
+                text: '시작하기',
+                isClickable: isAllRequiredAgreed,
+                onPressed: _onStartPressed,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
- #33 

## 🚀 Description
### 최초 회원가입 시 사용자 프로필 업데이트 구현을 완료하였습니다.

CategoryViewModel에서 SecureStorageRepository에 저장한 유저 정보를 불러와 putUsersProfiles service로 api 연동 작업 진행하였습니다. 

## 📸 Screenshot

https://github.com/user-attachments/assets/88ac932d-9f67-4339-bb9f-328bdbdb0fc1


## 📢 Notes
근처 동네 경우 홈에서는 동만, 글에서는 행정구까지 보여주기에 일단 디비에는 행정구 + 동 형태로 저장하였습니다. (ex. neighborhood : 관악구 봉천동) 
홈 상단 동네탭에서는 neighborhood를 불러오고 구를 빼서 동만 사용하고 게시글에서는 neighborhood 그대로 사용하시면 될 것으로 생각되는데 혹시 더 좋은 방법이나 더 편하신 방법이 있으시다면 리뷰로 남겨주세요!
