### PR TITLE
[Feat/#56] 사용자 관련 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,8 +231,5 @@ fabric.properties
 
 .env*
 
-*.freezed.dart
-*.g.dart
-
 android/app/google-services.json
 ios/Runner/GoogleServiceInfo.plist

--- a/lib/constants/apis.dart
+++ b/lib/constants/apis.dart
@@ -8,6 +8,7 @@ abstract class Apis {
 
   /// 토큰 관련 api
   static const String getAccessToken = "auth/mobile/google";
+  static const String getRefreshToken = "auth/tokens/refresh";
 
   /// 나눔글 관련 api
   static const String sharePosts = "share-posts";

--- a/lib/constants/apis.dart
+++ b/lib/constants/apis.dart
@@ -16,6 +16,8 @@ abstract class Apis {
   /// user 관련 api
   static const String putUsersProfiles = "users/profiles";
   static const String getUsersProfiles = "users/me/profile";
+  static const String logOut = "users/logout";
+  static const String signOut = "users/withdraw";
 
   /// share post 관련 api
   static const String createSharePosts = "share-posts";

--- a/lib/data/di/api_client.dart
+++ b/lib/data/di/api_client.dart
@@ -1,8 +1,10 @@
 import 'dart:developer';
 
 import 'package:anbd/data/repository/local/secure_storage_repository.dart';
+import 'package:anbd/data/service/auth_service.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get_it/get_it.dart';
 
 class ApiClient {
   static final ApiClient _instance = ApiClient._internal();
@@ -42,9 +44,51 @@ class ApiClient {
         log('응답 : ${response.statusCode}');
         return handler.next(response);
       },
-      onError: (DioException e, handler) {
-        /// 에러 처리
-        log('Error: ${e.message}');
+      onError: (DioException e, handler) async {
+        final requestOptions = e.requestOptions;
+
+        // 이미 재시도를 했거나, refresh 요청이라면 재시도 하지 않음
+        if (requestOptions.extra['retry'] == true ||
+            requestOptions.path.contains('reissue')) {
+          log('[Interceptor] 이미 토큰 재시도를 했거나 재발급 요청 자체가 실패했습니다. 재시도 중단.');
+          return handler.reject(e);
+        }
+
+        /// 406 error일 경우 토큰 재발급
+        if (e.response?.statusCode == 406) {
+          try {
+            log('[Interceptor] 406 → 토큰 재발급 시도 중...');
+
+            final authService = GetIt.instance<AuthService>();
+            await authService.getRefreshToken();
+
+            final newToken = await _secureStorage.readAccessToken();
+            if (newToken == null) throw Exception('재발급된 토큰이 없습니다.');
+
+            final clonedRequest = await _dio.request(
+              requestOptions.path,
+              data: requestOptions.data,
+              queryParameters: requestOptions.queryParameters,
+              options: Options(
+                method: requestOptions.method,
+                headers: {
+                  ...requestOptions.headers,
+                  'Authorization': 'Bearer $newToken',
+                },
+                extra: {
+                  ...requestOptions.extra,
+                  'retry': true,
+                },
+              ),
+            );
+
+            return handler.resolve(clonedRequest);
+          } catch (refreshError) {
+            log('[Interceptor] 토큰 재발급 실패: $refreshError');
+            return handler.reject(e); // 재발급 실패 시 기존 에러 반환
+          }
+        }
+
         return handler.next(e);
       },
     ));

--- a/lib/data/dto/response/bid_list_response.freezed.dart
+++ b/lib/data/dto/response/bid_list_response.freezed.dart
@@ -1,0 +1,615 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'bid_list_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+BidResponse _$BidResponseFromJson(Map<String, dynamic> json) {
+  return _BidResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$BidResponse {
+  int get id => throw _privateConstructorUsedError;
+  String get content => throw _privateConstructorUsedError;
+  int get donation => throw _privateConstructorUsedError;
+  bool? get isSelected => throw _privateConstructorUsedError;
+  UserInfo get user => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $BidResponseCopyWith<BidResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BidResponseCopyWith<$Res> {
+  factory $BidResponseCopyWith(
+          BidResponse value, $Res Function(BidResponse) then) =
+      _$BidResponseCopyWithImpl<$Res, BidResponse>;
+  @useResult
+  $Res call(
+      {int id,
+      String content,
+      int donation,
+      bool? isSelected,
+      UserInfo user,
+      DateTime createdAt,
+      DateTime updatedAt});
+
+  $UserInfoCopyWith<$Res> get user;
+}
+
+/// @nodoc
+class _$BidResponseCopyWithImpl<$Res, $Val extends BidResponse>
+    implements $BidResponseCopyWith<$Res> {
+  _$BidResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? content = null,
+    Object? donation = null,
+    Object? isSelected = freezed,
+    Object? user = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      donation: null == donation
+          ? _value.donation
+          : donation // ignore: cast_nullable_to_non_nullable
+              as int,
+      isSelected: freezed == isSelected
+          ? _value.isSelected
+          : isSelected // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserInfo,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $UserInfoCopyWith<$Res> get user {
+    return $UserInfoCopyWith<$Res>(_value.user, (value) {
+      return _then(_value.copyWith(user: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$BidResponseImplCopyWith<$Res>
+    implements $BidResponseCopyWith<$Res> {
+  factory _$$BidResponseImplCopyWith(
+          _$BidResponseImpl value, $Res Function(_$BidResponseImpl) then) =
+      __$$BidResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String content,
+      int donation,
+      bool? isSelected,
+      UserInfo user,
+      DateTime createdAt,
+      DateTime updatedAt});
+
+  @override
+  $UserInfoCopyWith<$Res> get user;
+}
+
+/// @nodoc
+class __$$BidResponseImplCopyWithImpl<$Res>
+    extends _$BidResponseCopyWithImpl<$Res, _$BidResponseImpl>
+    implements _$$BidResponseImplCopyWith<$Res> {
+  __$$BidResponseImplCopyWithImpl(
+      _$BidResponseImpl _value, $Res Function(_$BidResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? content = null,
+    Object? donation = null,
+    Object? isSelected = freezed,
+    Object? user = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_$BidResponseImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      donation: null == donation
+          ? _value.donation
+          : donation // ignore: cast_nullable_to_non_nullable
+              as int,
+      isSelected: freezed == isSelected
+          ? _value.isSelected
+          : isSelected // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      user: null == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as UserInfo,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$BidResponseImpl implements _BidResponse {
+  const _$BidResponseImpl(
+      {required this.id,
+      required this.content,
+      required this.donation,
+      this.isSelected,
+      required this.user,
+      required this.createdAt,
+      required this.updatedAt});
+
+  factory _$BidResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BidResponseImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String content;
+  @override
+  final int donation;
+  @override
+  final bool? isSelected;
+  @override
+  final UserInfo user;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+
+  @override
+  String toString() {
+    return 'BidResponse(id: $id, content: $content, donation: $donation, isSelected: $isSelected, user: $user, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BidResponseImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.donation, donation) ||
+                other.donation == donation) &&
+            (identical(other.isSelected, isSelected) ||
+                other.isSelected == isSelected) &&
+            (identical(other.user, user) || other.user == user) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, content, donation,
+      isSelected, user, createdAt, updatedAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BidResponseImplCopyWith<_$BidResponseImpl> get copyWith =>
+      __$$BidResponseImplCopyWithImpl<_$BidResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$BidResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _BidResponse implements BidResponse {
+  const factory _BidResponse(
+      {required final int id,
+      required final String content,
+      required final int donation,
+      final bool? isSelected,
+      required final UserInfo user,
+      required final DateTime createdAt,
+      required final DateTime updatedAt}) = _$BidResponseImpl;
+
+  factory _BidResponse.fromJson(Map<String, dynamic> json) =
+      _$BidResponseImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get content;
+  @override
+  int get donation;
+  @override
+  bool? get isSelected;
+  @override
+  UserInfo get user;
+  @override
+  DateTime get createdAt;
+  @override
+  DateTime get updatedAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$BidResponseImplCopyWith<_$BidResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+UserInfo _$UserInfoFromJson(Map<String, dynamic> json) {
+  return _UserInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserInfo {
+  int get userId => throw _privateConstructorUsedError;
+  String get nickname => throw _privateConstructorUsedError;
+  String get email => throw _privateConstructorUsedError;
+  String? get profileImage => throw _privateConstructorUsedError;
+  String get gender => throw _privateConstructorUsedError;
+  String? get birthDate => throw _privateConstructorUsedError;
+  String get neighborhood => throw _privateConstructorUsedError;
+  List<dynamic> get shareCategories => throw _privateConstructorUsedError;
+  int get reliability => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UserInfoCopyWith<UserInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserInfoCopyWith<$Res> {
+  factory $UserInfoCopyWith(UserInfo value, $Res Function(UserInfo) then) =
+      _$UserInfoCopyWithImpl<$Res, UserInfo>;
+  @useResult
+  $Res call(
+      {int userId,
+      String nickname,
+      String email,
+      String? profileImage,
+      String gender,
+      String? birthDate,
+      String neighborhood,
+      List<dynamic> shareCategories,
+      int reliability});
+}
+
+/// @nodoc
+class _$UserInfoCopyWithImpl<$Res, $Val extends UserInfo>
+    implements $UserInfoCopyWith<$Res> {
+  _$UserInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? nickname = null,
+    Object? email = null,
+    Object? profileImage = freezed,
+    Object? gender = null,
+    Object? birthDate = freezed,
+    Object? neighborhood = null,
+    Object? shareCategories = null,
+    Object? reliability = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: freezed == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      gender: null == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: freezed == birthDate
+          ? _value.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      neighborhood: null == neighborhood
+          ? _value.neighborhood
+          : neighborhood // ignore: cast_nullable_to_non_nullable
+              as String,
+      shareCategories: null == shareCategories
+          ? _value.shareCategories
+          : shareCategories // ignore: cast_nullable_to_non_nullable
+              as List<dynamic>,
+      reliability: null == reliability
+          ? _value.reliability
+          : reliability // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserInfoImplCopyWith<$Res>
+    implements $UserInfoCopyWith<$Res> {
+  factory _$$UserInfoImplCopyWith(
+          _$UserInfoImpl value, $Res Function(_$UserInfoImpl) then) =
+      __$$UserInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int userId,
+      String nickname,
+      String email,
+      String? profileImage,
+      String gender,
+      String? birthDate,
+      String neighborhood,
+      List<dynamic> shareCategories,
+      int reliability});
+}
+
+/// @nodoc
+class __$$UserInfoImplCopyWithImpl<$Res>
+    extends _$UserInfoCopyWithImpl<$Res, _$UserInfoImpl>
+    implements _$$UserInfoImplCopyWith<$Res> {
+  __$$UserInfoImplCopyWithImpl(
+      _$UserInfoImpl _value, $Res Function(_$UserInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? nickname = null,
+    Object? email = null,
+    Object? profileImage = freezed,
+    Object? gender = null,
+    Object? birthDate = freezed,
+    Object? neighborhood = null,
+    Object? shareCategories = null,
+    Object? reliability = null,
+  }) {
+    return _then(_$UserInfoImpl(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: freezed == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      gender: null == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: freezed == birthDate
+          ? _value.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      neighborhood: null == neighborhood
+          ? _value.neighborhood
+          : neighborhood // ignore: cast_nullable_to_non_nullable
+              as String,
+      shareCategories: null == shareCategories
+          ? _value._shareCategories
+          : shareCategories // ignore: cast_nullable_to_non_nullable
+              as List<dynamic>,
+      reliability: null == reliability
+          ? _value.reliability
+          : reliability // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UserInfoImpl implements _UserInfo {
+  const _$UserInfoImpl(
+      {required this.userId,
+      required this.nickname,
+      required this.email,
+      this.profileImage,
+      required this.gender,
+      this.birthDate,
+      required this.neighborhood,
+      required final List<dynamic> shareCategories,
+      required this.reliability})
+      : _shareCategories = shareCategories;
+
+  factory _$UserInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UserInfoImplFromJson(json);
+
+  @override
+  final int userId;
+  @override
+  final String nickname;
+  @override
+  final String email;
+  @override
+  final String? profileImage;
+  @override
+  final String gender;
+  @override
+  final String? birthDate;
+  @override
+  final String neighborhood;
+  final List<dynamic> _shareCategories;
+  @override
+  List<dynamic> get shareCategories {
+    if (_shareCategories is EqualUnmodifiableListView) return _shareCategories;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_shareCategories);
+  }
+
+  @override
+  final int reliability;
+
+  @override
+  String toString() {
+    return 'UserInfo(userId: $userId, nickname: $nickname, email: $email, profileImage: $profileImage, gender: $gender, birthDate: $birthDate, neighborhood: $neighborhood, shareCategories: $shareCategories, reliability: $reliability)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserInfoImpl &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.profileImage, profileImage) ||
+                other.profileImage == profileImage) &&
+            (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.neighborhood, neighborhood) ||
+                other.neighborhood == neighborhood) &&
+            const DeepCollectionEquality()
+                .equals(other._shareCategories, _shareCategories) &&
+            (identical(other.reliability, reliability) ||
+                other.reliability == reliability));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      userId,
+      nickname,
+      email,
+      profileImage,
+      gender,
+      birthDate,
+      neighborhood,
+      const DeepCollectionEquality().hash(_shareCategories),
+      reliability);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserInfoImplCopyWith<_$UserInfoImpl> get copyWith =>
+      __$$UserInfoImplCopyWithImpl<_$UserInfoImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UserInfoImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserInfo implements UserInfo {
+  const factory _UserInfo(
+      {required final int userId,
+      required final String nickname,
+      required final String email,
+      final String? profileImage,
+      required final String gender,
+      final String? birthDate,
+      required final String neighborhood,
+      required final List<dynamic> shareCategories,
+      required final int reliability}) = _$UserInfoImpl;
+
+  factory _UserInfo.fromJson(Map<String, dynamic> json) =
+      _$UserInfoImpl.fromJson;
+
+  @override
+  int get userId;
+  @override
+  String get nickname;
+  @override
+  String get email;
+  @override
+  String? get profileImage;
+  @override
+  String get gender;
+  @override
+  String? get birthDate;
+  @override
+  String get neighborhood;
+  @override
+  List<dynamic> get shareCategories;
+  @override
+  int get reliability;
+  @override
+  @JsonKey(ignore: true)
+  _$$UserInfoImplCopyWith<_$UserInfoImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/bid_list_response.g.dart
+++ b/lib/data/dto/response/bid_list_response.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bid_list_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$BidResponseImpl _$$BidResponseImplFromJson(Map<String, dynamic> json) =>
+    _$BidResponseImpl(
+      id: (json['id'] as num).toInt(),
+      content: json['content'] as String,
+      donation: (json['donation'] as num).toInt(),
+      isSelected: json['isSelected'] as bool?,
+      user: UserInfo.fromJson(json['user'] as Map<String, dynamic>),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$$BidResponseImplToJson(_$BidResponseImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'content': instance.content,
+      'donation': instance.donation,
+      'isSelected': instance.isSelected,
+      'user': instance.user,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+    };
+
+_$UserInfoImpl _$$UserInfoImplFromJson(Map<String, dynamic> json) =>
+    _$UserInfoImpl(
+      userId: (json['userId'] as num).toInt(),
+      nickname: json['nickname'] as String,
+      email: json['email'] as String,
+      profileImage: json['profileImage'] as String?,
+      gender: json['gender'] as String,
+      birthDate: json['birthDate'] as String?,
+      neighborhood: json['neighborhood'] as String,
+      shareCategories: json['shareCategories'] as List<dynamic>,
+      reliability: (json['reliability'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$UserInfoImplToJson(_$UserInfoImpl instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'nickname': instance.nickname,
+      'email': instance.email,
+      'profileImage': instance.profileImage,
+      'gender': instance.gender,
+      'birthDate': instance.birthDate,
+      'neighborhood': instance.neighborhood,
+      'shareCategories': instance.shareCategories,
+      'reliability': instance.reliability,
+    };

--- a/lib/data/dto/response/refresh_token_response.dart
+++ b/lib/data/dto/response/refresh_token_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'refresh_token_response.freezed.dart';
+part 'refresh_token_response.g.dart';
+
+@freezed
+class RefreshTokenResponse with _$RefreshTokenResponse {
+  const factory RefreshTokenResponse({
+    @JsonKey(name: 'accessToken') required String accessToken,
+    @JsonKey(name: 'refreshToken') required String refreshToken,
+  }) = _RefreshTokenResponse;
+
+  factory RefreshTokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$RefreshTokenResponseFromJson(json);
+}

--- a/lib/data/dto/response/refresh_token_response.freezed.dart
+++ b/lib/data/dto/response/refresh_token_response.freezed.dart
@@ -1,0 +1,187 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'refresh_token_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+RefreshTokenResponse _$RefreshTokenResponseFromJson(Map<String, dynamic> json) {
+  return _RefreshTokenResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$RefreshTokenResponse {
+  @JsonKey(name: 'accessToken')
+  String get accessToken => throw _privateConstructorUsedError;
+  @JsonKey(name: 'refreshToken')
+  String get refreshToken => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $RefreshTokenResponseCopyWith<RefreshTokenResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RefreshTokenResponseCopyWith<$Res> {
+  factory $RefreshTokenResponseCopyWith(RefreshTokenResponse value,
+          $Res Function(RefreshTokenResponse) then) =
+      _$RefreshTokenResponseCopyWithImpl<$Res, RefreshTokenResponse>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'accessToken') String accessToken,
+      @JsonKey(name: 'refreshToken') String refreshToken});
+}
+
+/// @nodoc
+class _$RefreshTokenResponseCopyWithImpl<$Res,
+        $Val extends RefreshTokenResponse>
+    implements $RefreshTokenResponseCopyWith<$Res> {
+  _$RefreshTokenResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accessToken = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_value.copyWith(
+      accessToken: null == accessToken
+          ? _value.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RefreshTokenResponseImplCopyWith<$Res>
+    implements $RefreshTokenResponseCopyWith<$Res> {
+  factory _$$RefreshTokenResponseImplCopyWith(_$RefreshTokenResponseImpl value,
+          $Res Function(_$RefreshTokenResponseImpl) then) =
+      __$$RefreshTokenResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'accessToken') String accessToken,
+      @JsonKey(name: 'refreshToken') String refreshToken});
+}
+
+/// @nodoc
+class __$$RefreshTokenResponseImplCopyWithImpl<$Res>
+    extends _$RefreshTokenResponseCopyWithImpl<$Res, _$RefreshTokenResponseImpl>
+    implements _$$RefreshTokenResponseImplCopyWith<$Res> {
+  __$$RefreshTokenResponseImplCopyWithImpl(_$RefreshTokenResponseImpl _value,
+      $Res Function(_$RefreshTokenResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accessToken = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_$RefreshTokenResponseImpl(
+      accessToken: null == accessToken
+          ? _value.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$RefreshTokenResponseImpl implements _RefreshTokenResponse {
+  const _$RefreshTokenResponseImpl(
+      {@JsonKey(name: 'accessToken') required this.accessToken,
+      @JsonKey(name: 'refreshToken') required this.refreshToken});
+
+  factory _$RefreshTokenResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RefreshTokenResponseImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'accessToken')
+  final String accessToken;
+  @override
+  @JsonKey(name: 'refreshToken')
+  final String refreshToken;
+
+  @override
+  String toString() {
+    return 'RefreshTokenResponse(accessToken: $accessToken, refreshToken: $refreshToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RefreshTokenResponseImpl &&
+            (identical(other.accessToken, accessToken) ||
+                other.accessToken == accessToken) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, accessToken, refreshToken);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RefreshTokenResponseImplCopyWith<_$RefreshTokenResponseImpl>
+      get copyWith =>
+          __$$RefreshTokenResponseImplCopyWithImpl<_$RefreshTokenResponseImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$RefreshTokenResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _RefreshTokenResponse implements RefreshTokenResponse {
+  const factory _RefreshTokenResponse(
+          {@JsonKey(name: 'accessToken') required final String accessToken,
+          @JsonKey(name: 'refreshToken') required final String refreshToken}) =
+      _$RefreshTokenResponseImpl;
+
+  factory _RefreshTokenResponse.fromJson(Map<String, dynamic> json) =
+      _$RefreshTokenResponseImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'accessToken')
+  String get accessToken;
+  @override
+  @JsonKey(name: 'refreshToken')
+  String get refreshToken;
+  @override
+  @JsonKey(ignore: true)
+  _$$RefreshTokenResponseImplCopyWith<_$RefreshTokenResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/refresh_token_response.g.dart
+++ b/lib/data/dto/response/refresh_token_response.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'refresh_token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$RefreshTokenResponseImpl _$$RefreshTokenResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$RefreshTokenResponseImpl(
+      accessToken: json['accessToken'] as String,
+      refreshToken: json['refreshToken'] as String,
+    );
+
+Map<String, dynamic> _$$RefreshTokenResponseImplToJson(
+        _$RefreshTokenResponseImpl instance) =>
+    <String, dynamic>{
+      'accessToken': instance.accessToken,
+      'refreshToken': instance.refreshToken,
+    };

--- a/lib/data/dto/response/share_all_post_response.freezed.dart
+++ b/lib/data/dto/response/share_all_post_response.freezed.dart
@@ -1,0 +1,898 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'share_all_post_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ShareAllPostResponse _$ShareAllPostResponseFromJson(Map<String, dynamic> json) {
+  return _ShareAllPostResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ShareAllPostResponse {
+  int get totalPages => throw _privateConstructorUsedError;
+  int get totalElements => throw _privateConstructorUsedError;
+  int get size => throw _privateConstructorUsedError;
+  List<SharePostResponse> get content => throw _privateConstructorUsedError;
+  int get number => throw _privateConstructorUsedError;
+  List<Sort> get sort => throw _privateConstructorUsedError;
+  int get numberOfElements => throw _privateConstructorUsedError;
+  Pageable get pageable => throw _privateConstructorUsedError;
+  bool get first => throw _privateConstructorUsedError;
+  bool get last => throw _privateConstructorUsedError;
+  bool get empty => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ShareAllPostResponseCopyWith<ShareAllPostResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ShareAllPostResponseCopyWith<$Res> {
+  factory $ShareAllPostResponseCopyWith(ShareAllPostResponse value,
+          $Res Function(ShareAllPostResponse) then) =
+      _$ShareAllPostResponseCopyWithImpl<$Res, ShareAllPostResponse>;
+  @useResult
+  $Res call(
+      {int totalPages,
+      int totalElements,
+      int size,
+      List<SharePostResponse> content,
+      int number,
+      List<Sort> sort,
+      int numberOfElements,
+      Pageable pageable,
+      bool first,
+      bool last,
+      bool empty});
+
+  $PageableCopyWith<$Res> get pageable;
+}
+
+/// @nodoc
+class _$ShareAllPostResponseCopyWithImpl<$Res,
+        $Val extends ShareAllPostResponse>
+    implements $ShareAllPostResponseCopyWith<$Res> {
+  _$ShareAllPostResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalPages = null,
+    Object? totalElements = null,
+    Object? size = null,
+    Object? content = null,
+    Object? number = null,
+    Object? sort = null,
+    Object? numberOfElements = null,
+    Object? pageable = null,
+    Object? first = null,
+    Object? last = null,
+    Object? empty = null,
+  }) {
+    return _then(_value.copyWith(
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalElements: null == totalElements
+          ? _value.totalElements
+          : totalElements // ignore: cast_nullable_to_non_nullable
+              as int,
+      size: null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as List<SharePostResponse>,
+      number: null == number
+          ? _value.number
+          : number // ignore: cast_nullable_to_non_nullable
+              as int,
+      sort: null == sort
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as List<Sort>,
+      numberOfElements: null == numberOfElements
+          ? _value.numberOfElements
+          : numberOfElements // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageable: null == pageable
+          ? _value.pageable
+          : pageable // ignore: cast_nullable_to_non_nullable
+              as Pageable,
+      first: null == first
+          ? _value.first
+          : first // ignore: cast_nullable_to_non_nullable
+              as bool,
+      last: null == last
+          ? _value.last
+          : last // ignore: cast_nullable_to_non_nullable
+              as bool,
+      empty: null == empty
+          ? _value.empty
+          : empty // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PageableCopyWith<$Res> get pageable {
+    return $PageableCopyWith<$Res>(_value.pageable, (value) {
+      return _then(_value.copyWith(pageable: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ShareAllPostResponseImplCopyWith<$Res>
+    implements $ShareAllPostResponseCopyWith<$Res> {
+  factory _$$ShareAllPostResponseImplCopyWith(_$ShareAllPostResponseImpl value,
+          $Res Function(_$ShareAllPostResponseImpl) then) =
+      __$$ShareAllPostResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int totalPages,
+      int totalElements,
+      int size,
+      List<SharePostResponse> content,
+      int number,
+      List<Sort> sort,
+      int numberOfElements,
+      Pageable pageable,
+      bool first,
+      bool last,
+      bool empty});
+
+  @override
+  $PageableCopyWith<$Res> get pageable;
+}
+
+/// @nodoc
+class __$$ShareAllPostResponseImplCopyWithImpl<$Res>
+    extends _$ShareAllPostResponseCopyWithImpl<$Res, _$ShareAllPostResponseImpl>
+    implements _$$ShareAllPostResponseImplCopyWith<$Res> {
+  __$$ShareAllPostResponseImplCopyWithImpl(_$ShareAllPostResponseImpl _value,
+      $Res Function(_$ShareAllPostResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalPages = null,
+    Object? totalElements = null,
+    Object? size = null,
+    Object? content = null,
+    Object? number = null,
+    Object? sort = null,
+    Object? numberOfElements = null,
+    Object? pageable = null,
+    Object? first = null,
+    Object? last = null,
+    Object? empty = null,
+  }) {
+    return _then(_$ShareAllPostResponseImpl(
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalElements: null == totalElements
+          ? _value.totalElements
+          : totalElements // ignore: cast_nullable_to_non_nullable
+              as int,
+      size: null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value._content
+          : content // ignore: cast_nullable_to_non_nullable
+              as List<SharePostResponse>,
+      number: null == number
+          ? _value.number
+          : number // ignore: cast_nullable_to_non_nullable
+              as int,
+      sort: null == sort
+          ? _value._sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as List<Sort>,
+      numberOfElements: null == numberOfElements
+          ? _value.numberOfElements
+          : numberOfElements // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageable: null == pageable
+          ? _value.pageable
+          : pageable // ignore: cast_nullable_to_non_nullable
+              as Pageable,
+      first: null == first
+          ? _value.first
+          : first // ignore: cast_nullable_to_non_nullable
+              as bool,
+      last: null == last
+          ? _value.last
+          : last // ignore: cast_nullable_to_non_nullable
+              as bool,
+      empty: null == empty
+          ? _value.empty
+          : empty // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ShareAllPostResponseImpl implements _ShareAllPostResponse {
+  const _$ShareAllPostResponseImpl(
+      {required this.totalPages,
+      required this.totalElements,
+      required this.size,
+      required final List<SharePostResponse> content,
+      required this.number,
+      required final List<Sort> sort,
+      required this.numberOfElements,
+      required this.pageable,
+      required this.first,
+      required this.last,
+      required this.empty})
+      : _content = content,
+        _sort = sort;
+
+  factory _$ShareAllPostResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ShareAllPostResponseImplFromJson(json);
+
+  @override
+  final int totalPages;
+  @override
+  final int totalElements;
+  @override
+  final int size;
+  final List<SharePostResponse> _content;
+  @override
+  List<SharePostResponse> get content {
+    if (_content is EqualUnmodifiableListView) return _content;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_content);
+  }
+
+  @override
+  final int number;
+  final List<Sort> _sort;
+  @override
+  List<Sort> get sort {
+    if (_sort is EqualUnmodifiableListView) return _sort;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sort);
+  }
+
+  @override
+  final int numberOfElements;
+  @override
+  final Pageable pageable;
+  @override
+  final bool first;
+  @override
+  final bool last;
+  @override
+  final bool empty;
+
+  @override
+  String toString() {
+    return 'ShareAllPostResponse(totalPages: $totalPages, totalElements: $totalElements, size: $size, content: $content, number: $number, sort: $sort, numberOfElements: $numberOfElements, pageable: $pageable, first: $first, last: $last, empty: $empty)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ShareAllPostResponseImpl &&
+            (identical(other.totalPages, totalPages) ||
+                other.totalPages == totalPages) &&
+            (identical(other.totalElements, totalElements) ||
+                other.totalElements == totalElements) &&
+            (identical(other.size, size) || other.size == size) &&
+            const DeepCollectionEquality().equals(other._content, _content) &&
+            (identical(other.number, number) || other.number == number) &&
+            const DeepCollectionEquality().equals(other._sort, _sort) &&
+            (identical(other.numberOfElements, numberOfElements) ||
+                other.numberOfElements == numberOfElements) &&
+            (identical(other.pageable, pageable) ||
+                other.pageable == pageable) &&
+            (identical(other.first, first) || other.first == first) &&
+            (identical(other.last, last) || other.last == last) &&
+            (identical(other.empty, empty) || other.empty == empty));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      totalPages,
+      totalElements,
+      size,
+      const DeepCollectionEquality().hash(_content),
+      number,
+      const DeepCollectionEquality().hash(_sort),
+      numberOfElements,
+      pageable,
+      first,
+      last,
+      empty);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ShareAllPostResponseImplCopyWith<_$ShareAllPostResponseImpl>
+      get copyWith =>
+          __$$ShareAllPostResponseImplCopyWithImpl<_$ShareAllPostResponseImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ShareAllPostResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ShareAllPostResponse implements ShareAllPostResponse {
+  const factory _ShareAllPostResponse(
+      {required final int totalPages,
+      required final int totalElements,
+      required final int size,
+      required final List<SharePostResponse> content,
+      required final int number,
+      required final List<Sort> sort,
+      required final int numberOfElements,
+      required final Pageable pageable,
+      required final bool first,
+      required final bool last,
+      required final bool empty}) = _$ShareAllPostResponseImpl;
+
+  factory _ShareAllPostResponse.fromJson(Map<String, dynamic> json) =
+      _$ShareAllPostResponseImpl.fromJson;
+
+  @override
+  int get totalPages;
+  @override
+  int get totalElements;
+  @override
+  int get size;
+  @override
+  List<SharePostResponse> get content;
+  @override
+  int get number;
+  @override
+  List<Sort> get sort;
+  @override
+  int get numberOfElements;
+  @override
+  Pageable get pageable;
+  @override
+  bool get first;
+  @override
+  bool get last;
+  @override
+  bool get empty;
+  @override
+  @JsonKey(ignore: true)
+  _$$ShareAllPostResponseImplCopyWith<_$ShareAllPostResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+Sort _$SortFromJson(Map<String, dynamic> json) {
+  return _Sort.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Sort {
+  String get direction => throw _privateConstructorUsedError;
+  String get property => throw _privateConstructorUsedError;
+  bool get ignoreCase => throw _privateConstructorUsedError;
+  String get nullHandling => throw _privateConstructorUsedError;
+  bool get ascending => throw _privateConstructorUsedError;
+  bool get descending => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SortCopyWith<Sort> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SortCopyWith<$Res> {
+  factory $SortCopyWith(Sort value, $Res Function(Sort) then) =
+      _$SortCopyWithImpl<$Res, Sort>;
+  @useResult
+  $Res call(
+      {String direction,
+      String property,
+      bool ignoreCase,
+      String nullHandling,
+      bool ascending,
+      bool descending});
+}
+
+/// @nodoc
+class _$SortCopyWithImpl<$Res, $Val extends Sort>
+    implements $SortCopyWith<$Res> {
+  _$SortCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? direction = null,
+    Object? property = null,
+    Object? ignoreCase = null,
+    Object? nullHandling = null,
+    Object? ascending = null,
+    Object? descending = null,
+  }) {
+    return _then(_value.copyWith(
+      direction: null == direction
+          ? _value.direction
+          : direction // ignore: cast_nullable_to_non_nullable
+              as String,
+      property: null == property
+          ? _value.property
+          : property // ignore: cast_nullable_to_non_nullable
+              as String,
+      ignoreCase: null == ignoreCase
+          ? _value.ignoreCase
+          : ignoreCase // ignore: cast_nullable_to_non_nullable
+              as bool,
+      nullHandling: null == nullHandling
+          ? _value.nullHandling
+          : nullHandling // ignore: cast_nullable_to_non_nullable
+              as String,
+      ascending: null == ascending
+          ? _value.ascending
+          : ascending // ignore: cast_nullable_to_non_nullable
+              as bool,
+      descending: null == descending
+          ? _value.descending
+          : descending // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SortImplCopyWith<$Res> implements $SortCopyWith<$Res> {
+  factory _$$SortImplCopyWith(
+          _$SortImpl value, $Res Function(_$SortImpl) then) =
+      __$$SortImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String direction,
+      String property,
+      bool ignoreCase,
+      String nullHandling,
+      bool ascending,
+      bool descending});
+}
+
+/// @nodoc
+class __$$SortImplCopyWithImpl<$Res>
+    extends _$SortCopyWithImpl<$Res, _$SortImpl>
+    implements _$$SortImplCopyWith<$Res> {
+  __$$SortImplCopyWithImpl(_$SortImpl _value, $Res Function(_$SortImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? direction = null,
+    Object? property = null,
+    Object? ignoreCase = null,
+    Object? nullHandling = null,
+    Object? ascending = null,
+    Object? descending = null,
+  }) {
+    return _then(_$SortImpl(
+      direction: null == direction
+          ? _value.direction
+          : direction // ignore: cast_nullable_to_non_nullable
+              as String,
+      property: null == property
+          ? _value.property
+          : property // ignore: cast_nullable_to_non_nullable
+              as String,
+      ignoreCase: null == ignoreCase
+          ? _value.ignoreCase
+          : ignoreCase // ignore: cast_nullable_to_non_nullable
+              as bool,
+      nullHandling: null == nullHandling
+          ? _value.nullHandling
+          : nullHandling // ignore: cast_nullable_to_non_nullable
+              as String,
+      ascending: null == ascending
+          ? _value.ascending
+          : ascending // ignore: cast_nullable_to_non_nullable
+              as bool,
+      descending: null == descending
+          ? _value.descending
+          : descending // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SortImpl implements _Sort {
+  const _$SortImpl(
+      {required this.direction,
+      required this.property,
+      required this.ignoreCase,
+      required this.nullHandling,
+      required this.ascending,
+      required this.descending});
+
+  factory _$SortImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SortImplFromJson(json);
+
+  @override
+  final String direction;
+  @override
+  final String property;
+  @override
+  final bool ignoreCase;
+  @override
+  final String nullHandling;
+  @override
+  final bool ascending;
+  @override
+  final bool descending;
+
+  @override
+  String toString() {
+    return 'Sort(direction: $direction, property: $property, ignoreCase: $ignoreCase, nullHandling: $nullHandling, ascending: $ascending, descending: $descending)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SortImpl &&
+            (identical(other.direction, direction) ||
+                other.direction == direction) &&
+            (identical(other.property, property) ||
+                other.property == property) &&
+            (identical(other.ignoreCase, ignoreCase) ||
+                other.ignoreCase == ignoreCase) &&
+            (identical(other.nullHandling, nullHandling) ||
+                other.nullHandling == nullHandling) &&
+            (identical(other.ascending, ascending) ||
+                other.ascending == ascending) &&
+            (identical(other.descending, descending) ||
+                other.descending == descending));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, direction, property, ignoreCase,
+      nullHandling, ascending, descending);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SortImplCopyWith<_$SortImpl> get copyWith =>
+      __$$SortImplCopyWithImpl<_$SortImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SortImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Sort implements Sort {
+  const factory _Sort(
+      {required final String direction,
+      required final String property,
+      required final bool ignoreCase,
+      required final String nullHandling,
+      required final bool ascending,
+      required final bool descending}) = _$SortImpl;
+
+  factory _Sort.fromJson(Map<String, dynamic> json) = _$SortImpl.fromJson;
+
+  @override
+  String get direction;
+  @override
+  String get property;
+  @override
+  bool get ignoreCase;
+  @override
+  String get nullHandling;
+  @override
+  bool get ascending;
+  @override
+  bool get descending;
+  @override
+  @JsonKey(ignore: true)
+  _$$SortImplCopyWith<_$SortImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Pageable _$PageableFromJson(Map<String, dynamic> json) {
+  return _Pageable.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Pageable {
+  int get offset => throw _privateConstructorUsedError;
+  List<Sort> get sort => throw _privateConstructorUsedError;
+  bool get unpaged => throw _privateConstructorUsedError;
+  bool get paged => throw _privateConstructorUsedError;
+  int get pageNumber => throw _privateConstructorUsedError;
+  int get pageSize => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PageableCopyWith<Pageable> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PageableCopyWith<$Res> {
+  factory $PageableCopyWith(Pageable value, $Res Function(Pageable) then) =
+      _$PageableCopyWithImpl<$Res, Pageable>;
+  @useResult
+  $Res call(
+      {int offset,
+      List<Sort> sort,
+      bool unpaged,
+      bool paged,
+      int pageNumber,
+      int pageSize});
+}
+
+/// @nodoc
+class _$PageableCopyWithImpl<$Res, $Val extends Pageable>
+    implements $PageableCopyWith<$Res> {
+  _$PageableCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offset = null,
+    Object? sort = null,
+    Object? unpaged = null,
+    Object? paged = null,
+    Object? pageNumber = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_value.copyWith(
+      offset: null == offset
+          ? _value.offset
+          : offset // ignore: cast_nullable_to_non_nullable
+              as int,
+      sort: null == sort
+          ? _value.sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as List<Sort>,
+      unpaged: null == unpaged
+          ? _value.unpaged
+          : unpaged // ignore: cast_nullable_to_non_nullable
+              as bool,
+      paged: null == paged
+          ? _value.paged
+          : paged // ignore: cast_nullable_to_non_nullable
+              as bool,
+      pageNumber: null == pageNumber
+          ? _value.pageNumber
+          : pageNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PageableImplCopyWith<$Res>
+    implements $PageableCopyWith<$Res> {
+  factory _$$PageableImplCopyWith(
+          _$PageableImpl value, $Res Function(_$PageableImpl) then) =
+      __$$PageableImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int offset,
+      List<Sort> sort,
+      bool unpaged,
+      bool paged,
+      int pageNumber,
+      int pageSize});
+}
+
+/// @nodoc
+class __$$PageableImplCopyWithImpl<$Res>
+    extends _$PageableCopyWithImpl<$Res, _$PageableImpl>
+    implements _$$PageableImplCopyWith<$Res> {
+  __$$PageableImplCopyWithImpl(
+      _$PageableImpl _value, $Res Function(_$PageableImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offset = null,
+    Object? sort = null,
+    Object? unpaged = null,
+    Object? paged = null,
+    Object? pageNumber = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_$PageableImpl(
+      offset: null == offset
+          ? _value.offset
+          : offset // ignore: cast_nullable_to_non_nullable
+              as int,
+      sort: null == sort
+          ? _value._sort
+          : sort // ignore: cast_nullable_to_non_nullable
+              as List<Sort>,
+      unpaged: null == unpaged
+          ? _value.unpaged
+          : unpaged // ignore: cast_nullable_to_non_nullable
+              as bool,
+      paged: null == paged
+          ? _value.paged
+          : paged // ignore: cast_nullable_to_non_nullable
+              as bool,
+      pageNumber: null == pageNumber
+          ? _value.pageNumber
+          : pageNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageableImpl implements _Pageable {
+  const _$PageableImpl(
+      {required this.offset,
+      required final List<Sort> sort,
+      required this.unpaged,
+      required this.paged,
+      required this.pageNumber,
+      required this.pageSize})
+      : _sort = sort;
+
+  factory _$PageableImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PageableImplFromJson(json);
+
+  @override
+  final int offset;
+  final List<Sort> _sort;
+  @override
+  List<Sort> get sort {
+    if (_sort is EqualUnmodifiableListView) return _sort;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sort);
+  }
+
+  @override
+  final bool unpaged;
+  @override
+  final bool paged;
+  @override
+  final int pageNumber;
+  @override
+  final int pageSize;
+
+  @override
+  String toString() {
+    return 'Pageable(offset: $offset, sort: $sort, unpaged: $unpaged, paged: $paged, pageNumber: $pageNumber, pageSize: $pageSize)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageableImpl &&
+            (identical(other.offset, offset) || other.offset == offset) &&
+            const DeepCollectionEquality().equals(other._sort, _sort) &&
+            (identical(other.unpaged, unpaged) || other.unpaged == unpaged) &&
+            (identical(other.paged, paged) || other.paged == paged) &&
+            (identical(other.pageNumber, pageNumber) ||
+                other.pageNumber == pageNumber) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      offset,
+      const DeepCollectionEquality().hash(_sort),
+      unpaged,
+      paged,
+      pageNumber,
+      pageSize);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageableImplCopyWith<_$PageableImpl> get copyWith =>
+      __$$PageableImplCopyWithImpl<_$PageableImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageableImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Pageable implements Pageable {
+  const factory _Pageable(
+      {required final int offset,
+      required final List<Sort> sort,
+      required final bool unpaged,
+      required final bool paged,
+      required final int pageNumber,
+      required final int pageSize}) = _$PageableImpl;
+
+  factory _Pageable.fromJson(Map<String, dynamic> json) =
+      _$PageableImpl.fromJson;
+
+  @override
+  int get offset;
+  @override
+  List<Sort> get sort;
+  @override
+  bool get unpaged;
+  @override
+  bool get paged;
+  @override
+  int get pageNumber;
+  @override
+  int get pageSize;
+  @override
+  @JsonKey(ignore: true)
+  _$$PageableImplCopyWith<_$PageableImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/share_all_post_response.g.dart
+++ b/lib/data/dto/response/share_all_post_response.g.dart
@@ -1,0 +1,84 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'share_all_post_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ShareAllPostResponseImpl _$$ShareAllPostResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ShareAllPostResponseImpl(
+      totalPages: (json['totalPages'] as num).toInt(),
+      totalElements: (json['totalElements'] as num).toInt(),
+      size: (json['size'] as num).toInt(),
+      content: (json['content'] as List<dynamic>)
+          .map((e) => SharePostResponse.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      number: (json['number'] as num).toInt(),
+      sort: (json['sort'] as List<dynamic>)
+          .map((e) => Sort.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      numberOfElements: (json['numberOfElements'] as num).toInt(),
+      pageable: Pageable.fromJson(json['pageable'] as Map<String, dynamic>),
+      first: json['first'] as bool,
+      last: json['last'] as bool,
+      empty: json['empty'] as bool,
+    );
+
+Map<String, dynamic> _$$ShareAllPostResponseImplToJson(
+        _$ShareAllPostResponseImpl instance) =>
+    <String, dynamic>{
+      'totalPages': instance.totalPages,
+      'totalElements': instance.totalElements,
+      'size': instance.size,
+      'content': instance.content,
+      'number': instance.number,
+      'sort': instance.sort,
+      'numberOfElements': instance.numberOfElements,
+      'pageable': instance.pageable,
+      'first': instance.first,
+      'last': instance.last,
+      'empty': instance.empty,
+    };
+
+_$SortImpl _$$SortImplFromJson(Map<String, dynamic> json) => _$SortImpl(
+      direction: json['direction'] as String,
+      property: json['property'] as String,
+      ignoreCase: json['ignoreCase'] as bool,
+      nullHandling: json['nullHandling'] as String,
+      ascending: json['ascending'] as bool,
+      descending: json['descending'] as bool,
+    );
+
+Map<String, dynamic> _$$SortImplToJson(_$SortImpl instance) =>
+    <String, dynamic>{
+      'direction': instance.direction,
+      'property': instance.property,
+      'ignoreCase': instance.ignoreCase,
+      'nullHandling': instance.nullHandling,
+      'ascending': instance.ascending,
+      'descending': instance.descending,
+    };
+
+_$PageableImpl _$$PageableImplFromJson(Map<String, dynamic> json) =>
+    _$PageableImpl(
+      offset: (json['offset'] as num).toInt(),
+      sort: (json['sort'] as List<dynamic>)
+          .map((e) => Sort.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      unpaged: json['unpaged'] as bool,
+      paged: json['paged'] as bool,
+      pageNumber: (json['pageNumber'] as num).toInt(),
+      pageSize: (json['pageSize'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$PageableImplToJson(_$PageableImpl instance) =>
+    <String, dynamic>{
+      'offset': instance.offset,
+      'sort': instance.sort,
+      'unpaged': instance.unpaged,
+      'paged': instance.paged,
+      'pageNumber': instance.pageNumber,
+      'pageSize': instance.pageSize,
+    };

--- a/lib/data/dto/response/share_post_response.freezed.dart
+++ b/lib/data/dto/response/share_post_response.freezed.dart
@@ -1,0 +1,486 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'share_post_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+SharePostResponse _$SharePostResponseFromJson(Map<String, dynamic> json) {
+  return _SharePostResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SharePostResponse {
+  int get id => throw _privateConstructorUsedError;
+  int get userId => throw _privateConstructorUsedError;
+  String? get title => throw _privateConstructorUsedError;
+  String? get category => throw _privateConstructorUsedError;
+  String? get content => throw _privateConstructorUsedError;
+  List<String> get images => throw _privateConstructorUsedError;
+  String? get type => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  String? get location => throw _privateConstructorUsedError;
+  bool get isSold => throw _privateConstructorUsedError;
+  int get hits => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+  int get likeCount => throw _privateConstructorUsedError;
+  bool get isLiked => throw _privateConstructorUsedError;
+  bool get isBid => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SharePostResponseCopyWith<SharePostResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SharePostResponseCopyWith<$Res> {
+  factory $SharePostResponseCopyWith(
+          SharePostResponse value, $Res Function(SharePostResponse) then) =
+      _$SharePostResponseCopyWithImpl<$Res, SharePostResponse>;
+  @useResult
+  $Res call(
+      {int id,
+      int userId,
+      String? title,
+      String? category,
+      String? content,
+      List<String> images,
+      String? type,
+      String? description,
+      String? location,
+      bool isSold,
+      int hits,
+      DateTime createdAt,
+      DateTime updatedAt,
+      int likeCount,
+      bool isLiked,
+      bool isBid});
+}
+
+/// @nodoc
+class _$SharePostResponseCopyWithImpl<$Res, $Val extends SharePostResponse>
+    implements $SharePostResponseCopyWith<$Res> {
+  _$SharePostResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = null,
+    Object? title = freezed,
+    Object? category = freezed,
+    Object? content = freezed,
+    Object? images = null,
+    Object? type = freezed,
+    Object? description = freezed,
+    Object? location = freezed,
+    Object? isSold = null,
+    Object? hits = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? likeCount = null,
+    Object? isLiked = null,
+    Object? isBid = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as String?,
+      content: freezed == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      images: null == images
+          ? _value.images
+          : images // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      type: freezed == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      location: freezed == location
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isSold: null == isSold
+          ? _value.isSold
+          : isSold // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hits: null == hits
+          ? _value.hits
+          : hits // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      likeCount: null == likeCount
+          ? _value.likeCount
+          : likeCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isLiked: null == isLiked
+          ? _value.isLiked
+          : isLiked // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isBid: null == isBid
+          ? _value.isBid
+          : isBid // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SharePostResponseImplCopyWith<$Res>
+    implements $SharePostResponseCopyWith<$Res> {
+  factory _$$SharePostResponseImplCopyWith(_$SharePostResponseImpl value,
+          $Res Function(_$SharePostResponseImpl) then) =
+      __$$SharePostResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      int userId,
+      String? title,
+      String? category,
+      String? content,
+      List<String> images,
+      String? type,
+      String? description,
+      String? location,
+      bool isSold,
+      int hits,
+      DateTime createdAt,
+      DateTime updatedAt,
+      int likeCount,
+      bool isLiked,
+      bool isBid});
+}
+
+/// @nodoc
+class __$$SharePostResponseImplCopyWithImpl<$Res>
+    extends _$SharePostResponseCopyWithImpl<$Res, _$SharePostResponseImpl>
+    implements _$$SharePostResponseImplCopyWith<$Res> {
+  __$$SharePostResponseImplCopyWithImpl(_$SharePostResponseImpl _value,
+      $Res Function(_$SharePostResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = null,
+    Object? title = freezed,
+    Object? category = freezed,
+    Object? content = freezed,
+    Object? images = null,
+    Object? type = freezed,
+    Object? description = freezed,
+    Object? location = freezed,
+    Object? isSold = null,
+    Object? hits = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? likeCount = null,
+    Object? isLiked = null,
+    Object? isBid = null,
+  }) {
+    return _then(_$SharePostResponseImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as String?,
+      content: freezed == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      images: null == images
+          ? _value._images
+          : images // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      type: freezed == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      location: freezed == location
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isSold: null == isSold
+          ? _value.isSold
+          : isSold // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hits: null == hits
+          ? _value.hits
+          : hits // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      likeCount: null == likeCount
+          ? _value.likeCount
+          : likeCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isLiked: null == isLiked
+          ? _value.isLiked
+          : isLiked // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isBid: null == isBid
+          ? _value.isBid
+          : isBid // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SharePostResponseImpl implements _SharePostResponse {
+  const _$SharePostResponseImpl(
+      {required this.id,
+      required this.userId,
+      required this.title,
+      required this.category,
+      required this.content,
+      required final List<String> images,
+      required this.type,
+      required this.description,
+      required this.location,
+      required this.isSold,
+      required this.hits,
+      required this.createdAt,
+      required this.updatedAt,
+      required this.likeCount,
+      required this.isLiked,
+      required this.isBid})
+      : _images = images;
+
+  factory _$SharePostResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SharePostResponseImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final int userId;
+  @override
+  final String? title;
+  @override
+  final String? category;
+  @override
+  final String? content;
+  final List<String> _images;
+  @override
+  List<String> get images {
+    if (_images is EqualUnmodifiableListView) return _images;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_images);
+  }
+
+  @override
+  final String? type;
+  @override
+  final String? description;
+  @override
+  final String? location;
+  @override
+  final bool isSold;
+  @override
+  final int hits;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+  @override
+  final int likeCount;
+  @override
+  final bool isLiked;
+  @override
+  final bool isBid;
+
+  @override
+  String toString() {
+    return 'SharePostResponse(id: $id, userId: $userId, title: $title, category: $category, content: $content, images: $images, type: $type, description: $description, location: $location, isSold: $isSold, hits: $hits, createdAt: $createdAt, updatedAt: $updatedAt, likeCount: $likeCount, isLiked: $isLiked, isBid: $isBid)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SharePostResponseImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.category, category) ||
+                other.category == category) &&
+            (identical(other.content, content) || other.content == content) &&
+            const DeepCollectionEquality().equals(other._images, _images) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.isSold, isSold) || other.isSold == isSold) &&
+            (identical(other.hits, hits) || other.hits == hits) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.likeCount, likeCount) ||
+                other.likeCount == likeCount) &&
+            (identical(other.isLiked, isLiked) || other.isLiked == isLiked) &&
+            (identical(other.isBid, isBid) || other.isBid == isBid));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      userId,
+      title,
+      category,
+      content,
+      const DeepCollectionEquality().hash(_images),
+      type,
+      description,
+      location,
+      isSold,
+      hits,
+      createdAt,
+      updatedAt,
+      likeCount,
+      isLiked,
+      isBid);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SharePostResponseImplCopyWith<_$SharePostResponseImpl> get copyWith =>
+      __$$SharePostResponseImplCopyWithImpl<_$SharePostResponseImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SharePostResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SharePostResponse implements SharePostResponse {
+  const factory _SharePostResponse(
+      {required final int id,
+      required final int userId,
+      required final String? title,
+      required final String? category,
+      required final String? content,
+      required final List<String> images,
+      required final String? type,
+      required final String? description,
+      required final String? location,
+      required final bool isSold,
+      required final int hits,
+      required final DateTime createdAt,
+      required final DateTime updatedAt,
+      required final int likeCount,
+      required final bool isLiked,
+      required final bool isBid}) = _$SharePostResponseImpl;
+
+  factory _SharePostResponse.fromJson(Map<String, dynamic> json) =
+      _$SharePostResponseImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  int get userId;
+  @override
+  String? get title;
+  @override
+  String? get category;
+  @override
+  String? get content;
+  @override
+  List<String> get images;
+  @override
+  String? get type;
+  @override
+  String? get description;
+  @override
+  String? get location;
+  @override
+  bool get isSold;
+  @override
+  int get hits;
+  @override
+  DateTime get createdAt;
+  @override
+  DateTime get updatedAt;
+  @override
+  int get likeCount;
+  @override
+  bool get isLiked;
+  @override
+  bool get isBid;
+  @override
+  @JsonKey(ignore: true)
+  _$$SharePostResponseImplCopyWith<_$SharePostResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/share_post_response.g.dart
+++ b/lib/data/dto/response/share_post_response.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'share_post_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SharePostResponseImpl _$$SharePostResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SharePostResponseImpl(
+      id: (json['id'] as num).toInt(),
+      userId: (json['userId'] as num).toInt(),
+      title: json['title'] as String?,
+      category: json['category'] as String?,
+      content: json['content'] as String?,
+      images:
+          (json['images'] as List<dynamic>).map((e) => e as String).toList(),
+      type: json['type'] as String?,
+      description: json['description'] as String?,
+      location: json['location'] as String?,
+      isSold: json['isSold'] as bool,
+      hits: (json['hits'] as num).toInt(),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      likeCount: (json['likeCount'] as num).toInt(),
+      isLiked: json['isLiked'] as bool,
+      isBid: json['isBid'] as bool,
+    );
+
+Map<String, dynamic> _$$SharePostResponseImplToJson(
+        _$SharePostResponseImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'userId': instance.userId,
+      'title': instance.title,
+      'category': instance.category,
+      'content': instance.content,
+      'images': instance.images,
+      'type': instance.type,
+      'description': instance.description,
+      'location': instance.location,
+      'isSold': instance.isSold,
+      'hits': instance.hits,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'likeCount': instance.likeCount,
+      'isLiked': instance.isLiked,
+      'isBid': instance.isBid,
+    };

--- a/lib/data/dto/response/token_response.freezed.dart
+++ b/lib/data/dto/response/token_response.freezed.dart
@@ -1,0 +1,209 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'token_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+TokenResponse _$TokenResponseFromJson(Map<String, dynamic> json) {
+  return _TokenResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TokenResponse {
+  @JsonKey(name: 'accessToken')
+  String get accessToken => throw _privateConstructorUsedError;
+  @JsonKey(name: 'refreshToken')
+  String get refreshToken => throw _privateConstructorUsedError;
+  @JsonKey(name: 'profileComplete')
+  bool get profileComplete => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TokenResponseCopyWith<TokenResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TokenResponseCopyWith<$Res> {
+  factory $TokenResponseCopyWith(
+          TokenResponse value, $Res Function(TokenResponse) then) =
+      _$TokenResponseCopyWithImpl<$Res, TokenResponse>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'accessToken') String accessToken,
+      @JsonKey(name: 'refreshToken') String refreshToken,
+      @JsonKey(name: 'profileComplete') bool profileComplete});
+}
+
+/// @nodoc
+class _$TokenResponseCopyWithImpl<$Res, $Val extends TokenResponse>
+    implements $TokenResponseCopyWith<$Res> {
+  _$TokenResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accessToken = null,
+    Object? refreshToken = null,
+    Object? profileComplete = null,
+  }) {
+    return _then(_value.copyWith(
+      accessToken: null == accessToken
+          ? _value.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileComplete: null == profileComplete
+          ? _value.profileComplete
+          : profileComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TokenResponseImplCopyWith<$Res>
+    implements $TokenResponseCopyWith<$Res> {
+  factory _$$TokenResponseImplCopyWith(
+          _$TokenResponseImpl value, $Res Function(_$TokenResponseImpl) then) =
+      __$$TokenResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'accessToken') String accessToken,
+      @JsonKey(name: 'refreshToken') String refreshToken,
+      @JsonKey(name: 'profileComplete') bool profileComplete});
+}
+
+/// @nodoc
+class __$$TokenResponseImplCopyWithImpl<$Res>
+    extends _$TokenResponseCopyWithImpl<$Res, _$TokenResponseImpl>
+    implements _$$TokenResponseImplCopyWith<$Res> {
+  __$$TokenResponseImplCopyWithImpl(
+      _$TokenResponseImpl _value, $Res Function(_$TokenResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accessToken = null,
+    Object? refreshToken = null,
+    Object? profileComplete = null,
+  }) {
+    return _then(_$TokenResponseImpl(
+      accessToken: null == accessToken
+          ? _value.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileComplete: null == profileComplete
+          ? _value.profileComplete
+          : profileComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TokenResponseImpl implements _TokenResponse {
+  const _$TokenResponseImpl(
+      {@JsonKey(name: 'accessToken') required this.accessToken,
+      @JsonKey(name: 'refreshToken') required this.refreshToken,
+      @JsonKey(name: 'profileComplete') required this.profileComplete});
+
+  factory _$TokenResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TokenResponseImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'accessToken')
+  final String accessToken;
+  @override
+  @JsonKey(name: 'refreshToken')
+  final String refreshToken;
+  @override
+  @JsonKey(name: 'profileComplete')
+  final bool profileComplete;
+
+  @override
+  String toString() {
+    return 'TokenResponse(accessToken: $accessToken, refreshToken: $refreshToken, profileComplete: $profileComplete)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TokenResponseImpl &&
+            (identical(other.accessToken, accessToken) ||
+                other.accessToken == accessToken) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken) &&
+            (identical(other.profileComplete, profileComplete) ||
+                other.profileComplete == profileComplete));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, accessToken, refreshToken, profileComplete);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TokenResponseImplCopyWith<_$TokenResponseImpl> get copyWith =>
+      __$$TokenResponseImplCopyWithImpl<_$TokenResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TokenResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TokenResponse implements TokenResponse {
+  const factory _TokenResponse(
+      {@JsonKey(name: 'accessToken') required final String accessToken,
+      @JsonKey(name: 'refreshToken') required final String refreshToken,
+      @JsonKey(name: 'profileComplete')
+      required final bool profileComplete}) = _$TokenResponseImpl;
+
+  factory _TokenResponse.fromJson(Map<String, dynamic> json) =
+      _$TokenResponseImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'accessToken')
+  String get accessToken;
+  @override
+  @JsonKey(name: 'refreshToken')
+  String get refreshToken;
+  @override
+  @JsonKey(name: 'profileComplete')
+  bool get profileComplete;
+  @override
+  @JsonKey(ignore: true)
+  _$$TokenResponseImplCopyWith<_$TokenResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/token_response.g.dart
+++ b/lib/data/dto/response/token_response.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TokenResponseImpl _$$TokenResponseImplFromJson(Map<String, dynamic> json) =>
+    _$TokenResponseImpl(
+      accessToken: json['accessToken'] as String,
+      refreshToken: json['refreshToken'] as String,
+      profileComplete: json['profileComplete'] as bool,
+    );
+
+Map<String, dynamic> _$$TokenResponseImplToJson(_$TokenResponseImpl instance) =>
+    <String, dynamic>{
+      'accessToken': instance.accessToken,
+      'refreshToken': instance.refreshToken,
+      'profileComplete': instance.profileComplete,
+    };

--- a/lib/data/dto/response/user_profiles_response.freezed.dart
+++ b/lib/data/dto/response/user_profiles_response.freezed.dart
@@ -1,0 +1,259 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_profiles_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+UserProfilesResponse _$UserProfilesResponseFromJson(Map<String, dynamic> json) {
+  return _UserProfilesResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserProfilesResponse {
+  @JsonKey(name: 'userId')
+  int get userId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'nickname')
+  String get nickname => throw _privateConstructorUsedError;
+  @JsonKey(name: 'profileImage')
+  String? get profileImage => throw _privateConstructorUsedError;
+  @JsonKey(name: 'neighborhood')
+  String get neighborhood => throw _privateConstructorUsedError;
+  @JsonKey(name: 'reliability')
+  int get reliability => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UserProfilesResponseCopyWith<UserProfilesResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserProfilesResponseCopyWith<$Res> {
+  factory $UserProfilesResponseCopyWith(UserProfilesResponse value,
+          $Res Function(UserProfilesResponse) then) =
+      _$UserProfilesResponseCopyWithImpl<$Res, UserProfilesResponse>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'userId') int userId,
+      @JsonKey(name: 'nickname') String nickname,
+      @JsonKey(name: 'profileImage') String? profileImage,
+      @JsonKey(name: 'neighborhood') String neighborhood,
+      @JsonKey(name: 'reliability') int reliability});
+}
+
+/// @nodoc
+class _$UserProfilesResponseCopyWithImpl<$Res,
+        $Val extends UserProfilesResponse>
+    implements $UserProfilesResponseCopyWith<$Res> {
+  _$UserProfilesResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? nickname = null,
+    Object? profileImage = freezed,
+    Object? neighborhood = null,
+    Object? reliability = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: freezed == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      neighborhood: null == neighborhood
+          ? _value.neighborhood
+          : neighborhood // ignore: cast_nullable_to_non_nullable
+              as String,
+      reliability: null == reliability
+          ? _value.reliability
+          : reliability // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserProfilesResponseImplCopyWith<$Res>
+    implements $UserProfilesResponseCopyWith<$Res> {
+  factory _$$UserProfilesResponseImplCopyWith(_$UserProfilesResponseImpl value,
+          $Res Function(_$UserProfilesResponseImpl) then) =
+      __$$UserProfilesResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'userId') int userId,
+      @JsonKey(name: 'nickname') String nickname,
+      @JsonKey(name: 'profileImage') String? profileImage,
+      @JsonKey(name: 'neighborhood') String neighborhood,
+      @JsonKey(name: 'reliability') int reliability});
+}
+
+/// @nodoc
+class __$$UserProfilesResponseImplCopyWithImpl<$Res>
+    extends _$UserProfilesResponseCopyWithImpl<$Res, _$UserProfilesResponseImpl>
+    implements _$$UserProfilesResponseImplCopyWith<$Res> {
+  __$$UserProfilesResponseImplCopyWithImpl(_$UserProfilesResponseImpl _value,
+      $Res Function(_$UserProfilesResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? nickname = null,
+    Object? profileImage = freezed,
+    Object? neighborhood = null,
+    Object? reliability = null,
+  }) {
+    return _then(_$UserProfilesResponseImpl(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: freezed == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      neighborhood: null == neighborhood
+          ? _value.neighborhood
+          : neighborhood // ignore: cast_nullable_to_non_nullable
+              as String,
+      reliability: null == reliability
+          ? _value.reliability
+          : reliability // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UserProfilesResponseImpl implements _UserProfilesResponse {
+  const _$UserProfilesResponseImpl(
+      {@JsonKey(name: 'userId') required this.userId,
+      @JsonKey(name: 'nickname') required this.nickname,
+      @JsonKey(name: 'profileImage') this.profileImage,
+      @JsonKey(name: 'neighborhood') required this.neighborhood,
+      @JsonKey(name: 'reliability') required this.reliability});
+
+  factory _$UserProfilesResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UserProfilesResponseImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'userId')
+  final int userId;
+  @override
+  @JsonKey(name: 'nickname')
+  final String nickname;
+  @override
+  @JsonKey(name: 'profileImage')
+  final String? profileImage;
+  @override
+  @JsonKey(name: 'neighborhood')
+  final String neighborhood;
+  @override
+  @JsonKey(name: 'reliability')
+  final int reliability;
+
+  @override
+  String toString() {
+    return 'UserProfilesResponse(userId: $userId, nickname: $nickname, profileImage: $profileImage, neighborhood: $neighborhood, reliability: $reliability)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserProfilesResponseImpl &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.profileImage, profileImage) ||
+                other.profileImage == profileImage) &&
+            (identical(other.neighborhood, neighborhood) ||
+                other.neighborhood == neighborhood) &&
+            (identical(other.reliability, reliability) ||
+                other.reliability == reliability));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, userId, nickname, profileImage, neighborhood, reliability);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserProfilesResponseImplCopyWith<_$UserProfilesResponseImpl>
+      get copyWith =>
+          __$$UserProfilesResponseImplCopyWithImpl<_$UserProfilesResponseImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UserProfilesResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserProfilesResponse implements UserProfilesResponse {
+  const factory _UserProfilesResponse(
+          {@JsonKey(name: 'userId') required final int userId,
+          @JsonKey(name: 'nickname') required final String nickname,
+          @JsonKey(name: 'profileImage') final String? profileImage,
+          @JsonKey(name: 'neighborhood') required final String neighborhood,
+          @JsonKey(name: 'reliability') required final int reliability}) =
+      _$UserProfilesResponseImpl;
+
+  factory _UserProfilesResponse.fromJson(Map<String, dynamic> json) =
+      _$UserProfilesResponseImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'userId')
+  int get userId;
+  @override
+  @JsonKey(name: 'nickname')
+  String get nickname;
+  @override
+  @JsonKey(name: 'profileImage')
+  String? get profileImage;
+  @override
+  @JsonKey(name: 'neighborhood')
+  String get neighborhood;
+  @override
+  @JsonKey(name: 'reliability')
+  int get reliability;
+  @override
+  @JsonKey(ignore: true)
+  _$$UserProfilesResponseImplCopyWith<_$UserProfilesResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/data/dto/response/user_profiles_response.g.dart
+++ b/lib/data/dto/response/user_profiles_response.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_profiles_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$UserProfilesResponseImpl _$$UserProfilesResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$UserProfilesResponseImpl(
+      userId: (json['userId'] as num).toInt(),
+      nickname: json['nickname'] as String,
+      profileImage: json['profileImage'] as String?,
+      neighborhood: json['neighborhood'] as String,
+      reliability: (json['reliability'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$UserProfilesResponseImplToJson(
+        _$UserProfilesResponseImpl instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'nickname': instance.nickname,
+      'profileImage': instance.profileImage,
+      'neighborhood': instance.neighborhood,
+      'reliability': instance.reliability,
+    };

--- a/lib/data/repository/local/secure_storage_repository.dart
+++ b/lib/data/repository/local/secure_storage_repository.dart
@@ -60,4 +60,9 @@ class SecureStorageRepository {
   Future<String?> readUserNearbyDistricts() async {
     return await _storage.read(key: "nearby_districts");
   }
+
+  ///모든 데이터 삭제
+  Future<void> deleteAllData() async {
+    await _storage.deleteAll();
+  }
 }

--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -109,4 +109,42 @@ class UserService {
       throw Exception('An unexpected error occurred: $e');
     }
   }
+
+  ///Post /v1/logout 로그아웃
+  Future<void> logOut() async {
+    try {
+      final response = await _apiClient.dio.post(
+        apiVersion + Apis.logOut,
+        options: Options(extra: {'skipAuthToken': false}),
+      );
+      if (response.statusCode == 200) {
+        log("로그아웃 성공");
+      } else {
+        throw Exception('Failed to send verification code ${response.data}');
+      }
+    } on DioException catch (e) {
+      throw Exception('Error: ${e.response?.data ?? e.message}');
+    } catch (e) {
+      throw Exception('An unexpected error occurred: $e');
+    }
+  }
+
+  ///DELETE /v1/users/withdraw 탈퇴하기
+  Future<void> signOut() async {
+    try {
+      final response = await _apiClient.dio.delete(
+        apiVersion + Apis.signOut,
+        options: Options(extra: {'skipAuthToken': false}),
+      );
+      if (response.statusCode == 200) {
+        log("탈퇴 성공");
+      } else {
+        throw Exception('Failed to send verification code ${response.data}');
+      }
+    } on DioException catch (e) {
+      throw Exception('Error: ${e.response?.data ?? e.message}');
+    } catch (e) {
+      throw Exception('An unexpected error occurred: $e');
+    }
+  }
 }

--- a/lib/models/product_detail_model.freezed.dart
+++ b/lib/models/product_detail_model.freezed.dart
@@ -1,0 +1,292 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'product_detail_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ProductDetail _$ProductDetailFromJson(Map<String, dynamic> json) {
+  return _ProductDetail.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ProductDetail {
+  int get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get content => throw _privateConstructorUsedError;
+  List<String> get images => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  int get likeCount => throw _privateConstructorUsedError;
+  bool get isLiked => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ProductDetailCopyWith<ProductDetail> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProductDetailCopyWith<$Res> {
+  factory $ProductDetailCopyWith(
+          ProductDetail value, $Res Function(ProductDetail) then) =
+      _$ProductDetailCopyWithImpl<$Res, ProductDetail>;
+  @useResult
+  $Res call(
+      {int id,
+      String title,
+      String content,
+      List<String> images,
+      String description,
+      int likeCount,
+      bool isLiked});
+}
+
+/// @nodoc
+class _$ProductDetailCopyWithImpl<$Res, $Val extends ProductDetail>
+    implements $ProductDetailCopyWith<$Res> {
+  _$ProductDetailCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? content = null,
+    Object? images = null,
+    Object? description = null,
+    Object? likeCount = null,
+    Object? isLiked = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      images: null == images
+          ? _value.images
+          : images // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      likeCount: null == likeCount
+          ? _value.likeCount
+          : likeCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isLiked: null == isLiked
+          ? _value.isLiked
+          : isLiked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ProductDetailImplCopyWith<$Res>
+    implements $ProductDetailCopyWith<$Res> {
+  factory _$$ProductDetailImplCopyWith(
+          _$ProductDetailImpl value, $Res Function(_$ProductDetailImpl) then) =
+      __$$ProductDetailImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String title,
+      String content,
+      List<String> images,
+      String description,
+      int likeCount,
+      bool isLiked});
+}
+
+/// @nodoc
+class __$$ProductDetailImplCopyWithImpl<$Res>
+    extends _$ProductDetailCopyWithImpl<$Res, _$ProductDetailImpl>
+    implements _$$ProductDetailImplCopyWith<$Res> {
+  __$$ProductDetailImplCopyWithImpl(
+      _$ProductDetailImpl _value, $Res Function(_$ProductDetailImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? content = null,
+    Object? images = null,
+    Object? description = null,
+    Object? likeCount = null,
+    Object? isLiked = null,
+  }) {
+    return _then(_$ProductDetailImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      images: null == images
+          ? _value._images
+          : images // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      likeCount: null == likeCount
+          ? _value.likeCount
+          : likeCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isLiked: null == isLiked
+          ? _value.isLiked
+          : isLiked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ProductDetailImpl implements _ProductDetail {
+  const _$ProductDetailImpl(
+      {required this.id,
+      required this.title,
+      required this.content,
+      required final List<String> images,
+      required this.description,
+      required this.likeCount,
+      required this.isLiked})
+      : _images = images;
+
+  factory _$ProductDetailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ProductDetailImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String title;
+  @override
+  final String content;
+  final List<String> _images;
+  @override
+  List<String> get images {
+    if (_images is EqualUnmodifiableListView) return _images;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_images);
+  }
+
+  @override
+  final String description;
+  @override
+  final int likeCount;
+  @override
+  final bool isLiked;
+
+  @override
+  String toString() {
+    return 'ProductDetail(id: $id, title: $title, content: $content, images: $images, description: $description, likeCount: $likeCount, isLiked: $isLiked)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProductDetailImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.content, content) || other.content == content) &&
+            const DeepCollectionEquality().equals(other._images, _images) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.likeCount, likeCount) ||
+                other.likeCount == likeCount) &&
+            (identical(other.isLiked, isLiked) || other.isLiked == isLiked));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      title,
+      content,
+      const DeepCollectionEquality().hash(_images),
+      description,
+      likeCount,
+      isLiked);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ProductDetailImplCopyWith<_$ProductDetailImpl> get copyWith =>
+      __$$ProductDetailImplCopyWithImpl<_$ProductDetailImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ProductDetailImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ProductDetail implements ProductDetail {
+  const factory _ProductDetail(
+      {required final int id,
+      required final String title,
+      required final String content,
+      required final List<String> images,
+      required final String description,
+      required final int likeCount,
+      required final bool isLiked}) = _$ProductDetailImpl;
+
+  factory _ProductDetail.fromJson(Map<String, dynamic> json) =
+      _$ProductDetailImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get title;
+  @override
+  String get content;
+  @override
+  List<String> get images;
+  @override
+  String get description;
+  @override
+  int get likeCount;
+  @override
+  bool get isLiked;
+  @override
+  @JsonKey(ignore: true)
+  _$$ProductDetailImplCopyWith<_$ProductDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/product_detail_model.g.dart
+++ b/lib/models/product_detail_model.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'product_detail_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ProductDetailImpl _$$ProductDetailImplFromJson(Map<String, dynamic> json) =>
+    _$ProductDetailImpl(
+      id: (json['id'] as num).toInt(),
+      title: json['title'] as String,
+      content: json['content'] as String,
+      images:
+          (json['images'] as List<dynamic>).map((e) => e as String).toList(),
+      description: json['description'] as String,
+      likeCount: (json['likeCount'] as num).toInt(),
+      isLiked: json['isLiked'] as bool,
+    );
+
+Map<String, dynamic> _$$ProductDetailImplToJson(_$ProductDetailImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'content': instance.content,
+      'images': instance.images,
+      'description': instance.description,
+      'likeCount': instance.likeCount,
+      'isLiked': instance.isLiked,
+    };

--- a/lib/screens/auth/login/login_screen.dart
+++ b/lib/screens/auth/login/login_screen.dart
@@ -45,13 +45,13 @@ class LoginScreen extends StatelessWidget {
                       platform: LoginPlatform.google,
                       onTap: () async {
                         await viewModel.signInWithGoogle();
-                        context.push(Paths.question);
-                        //TODO 자동로그인 구현
-                        /*if (viewModel.isNewUser) {
-                          context.push(Paths.question);
+
+                        /// 자동 로그인
+                        if (viewModel.profileComplete == true) {
+                          context.push((Paths.home));
                         } else {
-                          context.push(Paths.home);
-                        }*/
+                          context.push(Paths.question);
+                        }
                       },
                     ),
                     const SizedBox(height: 15),
@@ -73,7 +73,7 @@ class LoginScreen extends StatelessWidget {
                         const SizedBox(width: 5),
                         GestureDetector(
                           onTap: () => context.push(Paths.home),
-                          child : Text(
+                          child: Text(
                             '둘러보기',
                             style: AnbdTextStyle.BodyL12.copyWith(
                                 color: AnbdColor.blue),

--- a/lib/screens/auth/login/login_view_model.dart
+++ b/lib/screens/auth/login/login_view_model.dart
@@ -63,7 +63,9 @@ class LoginViewModel extends ChangeNotifier {
 
         if (e is DioException) {
           log("DioError details: ${e.response?.data}");
+          rethrow;
         }
+        rethrow;
         notifyListeners();
       }
     }

--- a/lib/screens/auth/login/login_view_model.dart
+++ b/lib/screens/auth/login/login_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:anbd/common/enums/login_platform.dart';
 import 'package:anbd/data/repository/local/secure_storage_repository.dart';
 import 'package:anbd/data/service/auth_service.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
@@ -23,6 +24,8 @@ class LoginViewModel extends ChangeNotifier {
   late bool _isNewUser;
 
   bool get isNewUser => _isNewUser;
+
+  bool? profileComplete;
 
   Future<void> signInWithGoogle() async {
     final GoogleSignIn googleSignIn = Platform.isIOS
@@ -46,13 +49,23 @@ class LoginViewModel extends ChangeNotifier {
       final authCode = googleSignInAuthentication.accessToken;
       log("토큰: $authCode");
 
-      /// 사용자 정보 저장(이름, 이메일)
-      await _saveUserInfo(googleUser.displayName, googleUser.email);
+      try {
+        final response = await authService.getAccessToken(authCode!);
 
-      /// 서버에서 구글 authCode로 access Token 받아오기
-      await authService.getAccessToken(authCode!);
+        await _saveUserInfo(googleUser.displayName, googleUser.email);
+        _loginPlatform = LoginPlatform.google;
+        profileComplete = response.profileComplete;
 
-      _loginPlatform = LoginPlatform.google;
+        notifyListeners();
+      } catch (e) {
+        log("Exception occurred: $e");
+        _errorMessage = 'Google 로그인에 실패했습니다. 다시 시도해주세요.';
+
+        if (e is DioException) {
+          log("DioError details: ${e.response?.data}");
+        }
+        notifyListeners();
+      }
     }
   }
 

--- a/lib/screens/mypage/mypage_screen.dart
+++ b/lib/screens/mypage/mypage_screen.dart
@@ -2,6 +2,7 @@ import 'package:anbd/constants/constants.dart';
 import 'package:anbd/screens/mypage/mypage_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 class MyPageScreen extends StatelessWidget {
@@ -90,12 +91,35 @@ class MyPageScreen extends StatelessWidget {
           /// 기타
           const Text("기타", style: AnbdTextStyle.BodySB15),
           const SizedBox(height: 20),
-          const Text("로그아웃", style: AnbdTextStyle.BodySB15),
+
+          Consumer<MyPageViewModel>(
+            builder: (context, viewModel, _) => GestureDetector(
+              onTap: () {
+                viewModel.logOut();
+                context.push(Paths.login);
+              },
+              child: const Text(
+                "로그아웃",
+                style: AnbdTextStyle.BodySB15,
+              ),
+            ),
+          ),
           const SizedBox(height: 15),
 
-          Text("회원탈퇴",
-              style: AnbdTextStyle.BodySB15.copyWith(
-                  color: AnbdColor.systemGray03)),
+          Consumer<MyPageViewModel>(
+            builder: (context, viewModel, _) => GestureDetector(
+              onTap: () {
+                viewModel.signOut(context);
+                context.push(Paths.login);
+              },
+              child: Text(
+                "회원탈퇴",
+                style: AnbdTextStyle.BodySB15.copyWith(
+                  color: AnbdColor.systemGray03,
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/screens/mypage/mypage_view_model.dart
+++ b/lib/screens/mypage/mypage_view_model.dart
@@ -1,10 +1,12 @@
 import 'dart:developer';
 
+import 'package:anbd/data/repository/local/secure_storage_repository.dart';
 import 'package:anbd/data/service/user_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 class MyPageViewModel extends ChangeNotifier {
+  final SecureStorageRepository _secureStorage = SecureStorageRepository();
   final UserService userService = GetIt.instance<UserService>();
 
   String _currentLocation = '마이페이지'; // 기본 위치 이름
@@ -28,5 +30,14 @@ class MyPageViewModel extends ChangeNotifier {
     name = response.nickname;
     log("이름 $name");
     notifyListeners();
+  }
+
+  Future<void> logOut() async {
+    _secureStorage.deleteAllData();
+  }
+
+  Future<void> signOut(BuildContext context) async {
+    await userService.signOut();
+    await _secureStorage.deleteAllData();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,18 +29,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -737,18 +737,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -777,26 +777,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -1065,7 +1065,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   smooth_page_indicator:
     dependency: "direct main"
     description:
@@ -1094,10 +1094,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sprintf:
     dependency: transitive
     description:
@@ -1110,18 +1110,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1134,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.2.0"
   syncfusion_flutter_core:
     dependency: transitive
     description:
@@ -1158,18 +1158,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.0"
   timeago:
     dependency: "direct main"
     description:
@@ -1238,10 +1238,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -1299,5 +1299,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.4.3 <4.0.0"
   flutter: ">=3.22.0"


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
- Relove #56

## 🚀 Description
### freezed 파일 gitignore 해제
이전엔 freezed로 생성한 파일 중 .freezed.dart, .g.dart 파일들의 양이 많아 깃이그로어에 추가하여 관리하였습니다. 하지만 매번 새로 빌드하는게 불편하다는 생각되어 깃이그노어에서 해제했습니다.

### 자동 로그인
profileComplete 값을 사용하여 true일 경우 바로 자동으로 로그인 되도록 수정하였습니다. 또한 이에 맞게 라우팅 처리 완료하였습니다.
그러므로 한 번 회원가입 한 이후부턴 바로 홈으로 이동할 수 있습니다.

### 토큰 만료 406 Interceptor
토큰 만료시에 api 호출하면 406 오류가 뜨는데 이때 api client interceptor error쪽에 406 오류일 경우 refresh token api를 호출하여 새로운 토큰을 발급 받고 이후 이전에 오류났던 api를 다시 요청하도록 설정해놓았습니다.

### logout, signout api 연결
사용자 로그아웃, 사용자 계정 삭제 api를 연결하여 두 기능을 구현하였습니다. 둘 다 실행되고 나서 로컬에 있던 값은 삭제되도록 설정하였습니다.

## 📸 Screenshot

## 📢 Notes
